### PR TITLE
Update `Usage` section to include helpful option for scdaemon

### DIFF
--- a/yubicoauthenticator/text.py
+++ b/yubicoauthenticator/text.py
@@ -37,7 +37,10 @@ Plug in your Yubikey NEO in one of the USB port available on your computer. Be s
 
 3) Click once on the displayed values to copy text to the clipboard. Double click to copy text and minimize the window.
 
-4) To quit the application right click on the Yubico icon (Y) in the taskbar and select Exit (or you can use ctrl + Q)"""
+4) To quit the application right click on the Yubico icon (Y) in the taskbar and select Exit (or you can use ctrl + Q)
+
+In case you are also using gpg, make sure to add "card-timeout 5" to  ~/.gnupg/scdaemon.conf
+"""
 
 
 


### PR DESCRIPTION
It seems that Neo cannot be used by both gpg and Authenticator at the same time.
The problem is more severe, as gpg-agent and scdaemon by default tend to leave connection to card open indefinitely.
This makes opening Authenticator after any usage of gpg fail with error:
```
No Yubikey NEO found. Please plugin your Yubikey NEO in one of your USB port
```

This change advises user to add configuration option that will instruct gpg-agent and scdaemon to close connection to card after 5 seconds of inactivity. 