### PR TITLE
Handle case when no space left on YubiKey

### DIFF
--- a/yubioath/cli/__main__.py
+++ b/yubioath/cli/__main__.py
@@ -32,6 +32,7 @@ from .. import __version__
 from ..core.ccid import open_scard
 from ..core.standard import TYPE_HOTP, TYPE_TOTP
 from ..core.utils import parse_uri
+from ..core.exc import NoSpaceError
 from .keystore import get_keystore
 from .controller import CliController
 from time import time
@@ -161,8 +162,12 @@ def put(ctx, key, destination, name, oath_type, digits, imf, touch):
         dev = ctx.obj['dev'] or ctx.fail('No YubiKey found!')
         name = name or click.prompt('Enter a name for the credential')
         oath_type = TYPE_TOTP if oath_type == 'totp' else TYPE_HOTP
-        controller.add_cred(dev, name, key, oath_type, digits=digits, imf=imf,
-                            require_touch=touch)
+        try:
+            controller.add_cred(dev, name, key, oath_type, digits=digits,
+                                imf=imf, require_touch=touch)
+        except NoSpaceError:
+            ctx.fail('There is no space available on your device. Maybe you '
+                     'can delete som entries?')
     else:
         controller.add_cred_legacy(destination, key, touch)
 

--- a/yubioath/core/exc.py
+++ b/yubioath/core/exc.py
@@ -39,6 +39,12 @@ class DeviceLockedError(Exception):
         super(DeviceLockedError, self).__init__('Device is locked!')
 
 
+class NoSpaceError(Exception):
+
+    def __init__(self):
+        super(NoSpaceError, self).__init__('No space available on device.')
+
+
 class InvalidSlotError(Exception):
 
     def __init__(self):

--- a/yubioath/core/standard.py
+++ b/yubioath/core/standard.py
@@ -26,7 +26,7 @@
 
 from __future__ import print_function, division
 
-from .exc import CardError, DeviceLockedError
+from .exc import CardError, DeviceLockedError, NoSpaceError
 from .utils import (der_read, der_pack, hmac_sha1, derive_key, get_random_bytes,
                     time_challenge, parse_truncated, format_code)
 from yubioath.yubicommon.compat import int2byte, byte2int
@@ -34,6 +34,7 @@ import hashlib
 import struct
 
 YKOATH_AID = b'\xa0\x00\x00\x05\x27\x21\x01\x01'
+YKOATH_NO_SPACE=0x6a84
 
 INS_PUT = 0x01
 INS_DELETE = 0x02
@@ -179,6 +180,10 @@ class YubiOathCcid(object):
             more, status = self._device.send_apdu(
                 0, INS_SEND_REMAINING, 0, 0, '')
             resp += more
+        
+        if status == YKOATH_NO_SPACE:
+            raise NoSpaceError()
+
         if expected != status:
             raise CardError(status)
         return resp

--- a/yubioath/gui/__main__.py
+++ b/yubioath/gui/__main__.py
@@ -36,6 +36,7 @@ try:
 except ImportError:
     ykpers_version = 'None'
 from ..core.utils import kill_scdaemon
+from ..core.exc import NoSpaceError
 from . import messages as m
 from .controller import GuiController
 from .ccid import CardStatus
@@ -216,11 +217,13 @@ class YubiOathApplication(qt.Application):
                     QtGui.QMessageBox.critical(
                         self.window, m.key_removed, m.key_removed_desc)
                 else:
-                    self._controller.add_cred(
+                    try:
+                        self._controller.add_cred(
                         dialog.name, dialog.key, oath_type=dialog.oath_type,
                         digits=dialog.n_digits,
-                        require_touch=dialog.require_touch
-                    )
+                        require_touch=dialog.require_touch)
+                    except NoSpaceError:
+                        QtGui.QMessageBox.critical(self.window, m.no_space, m.no_space_desc)
         elif c.otp:
             dialog = AddCredLegacyDialog(self.worker, c.otp, parent=self.window)
             if dialog.exec_():

--- a/yubioath/gui/messages.py
+++ b/yubioath/gui/messages.py
@@ -126,7 +126,8 @@ ccid_disabled = '<b>CCID (smart card capabilities) is disabled on the ' \
     'inserted YubiKey.</b><br><br>Without CCID enabled, you will only be ' \
     'able to store 2 credentials.<br><br>' \
     '<a href="%s">Learn how to enable CCID</a><br>'
-
+no_space="No space available"
+no_space_desc="There is no space available on your device. Maybe you can delete som entries?"
 
 def _translate(qt):
     values = globals()


### PR DESCRIPTION
When a Yubikey has no space left for OATH credentials,
it will return the response code 0x6a84.
Inform the user of this in the gui and client.