### PR TITLE
gui controller: unset _reader and _creds on forget_passwords()

### DIFF
--- a/yubioath/gui/controller.py
+++ b/yubioath/gui/controller.py
@@ -417,4 +417,5 @@ class GuiController(QtCore.QObject, Controller):
     def forget_passwords(self):
         self._reader = None
         self._creds = None
+        self.watcher.close()
         self._keystore.forget()

--- a/yubioath/gui/controller.py
+++ b/yubioath/gui/controller.py
@@ -415,4 +415,6 @@ class GuiController(QtCore.QObject, Controller):
                 self._keystore.put(dev.id, key, remember)
 
     def forget_passwords(self):
+        self._reader = None
+        self._creds = None
         self._keystore.forget()


### PR DESCRIPTION
I was running into this exception when I restore the app from the system tray:

```
    Traceback (most recent call last):
      File "/usr/lib/python2.7/site-packages/yubioath/yubicommon/qt/classes.py", line 86, in customEvent
	event.callback()
      File "/usr/lib/python2.7/site-packages/yubioath/yubicommon/qt/worker.py", line 48, in callback
	self._callback()
      File "/usr/lib/python2.7/site-packages/yubioath/gui/controller.py", line 262, in _init_dev
	dev.unlock(self._keystore.get(dev.id))
      File "/usr/lib/python2.7/site-packages/yubioath/core/standard.py", line 241, in unlock
	resp = self._send(INS_VALIDATE, data)
      File "/usr/lib/python2.7/site-packages/yubioath/core/standard.py", line 179, in _send
	resp, status = self._device.send_apdu(0, ins, p1, p2, data)
      File "/usr/lib/python2.7/site-packages/yubioath/core/ccid.py", line 48, in send_apdu
	resp, sw1, sw2 = self._conn.transmit(header + [byte2int(b) for b in data])
      File "/usr/lib/python2.7/site-packages/smartcard/CardConnectionDecorator.py", line 82, in transmit
	return self.component.transmit(bytes, protocol)
      File "/usr/lib/python2.7/site-packages/smartcard/CardConnection.py", line 146, in transmit
	data, sw1, sw2 = self.doTransmit(bytes, protocol)
      File "/usr/lib/python2.7/site-packages/smartcard/pcsc/PCSCCardConnection.py", line 205, in doTransmit
	SCardGetErrorMessage(hresult))
    CardConnectionException: Failed to transmit with protocol T1. Card was reset.
```

Killing off the existing 'reader' object is sufficient to tell it to reconnect to the reader properly before trying to do anything with it.