### PR TITLE
Allow 7 digits

### DIFF
--- a/yubioath/cli/__main__.py
+++ b/yubioath/cli/__main__.py
@@ -30,7 +30,7 @@ from __future__ import print_function
 
 from .. import __version__
 from ..core.ccid import open_scard
-from ..core.standard import ALG_SHA1, ALG_SHA256, TYPE_HOTP, TYPE_TOTP
+from ..core.standard import DEFAULT_DIGITS, ALLOWED_DIGITS, ALG_SHA1, ALG_SHA256, TYPE_HOTP, TYPE_TOTP
 from ..core.utils import parse_uri
 from ..core.exc import NoSpaceError
 from .keystore import get_keystore
@@ -138,7 +138,7 @@ def show(ctx, query, slot1, slot2, timestamp):
 @click.option(
     '-A', '--oath-type', type=click.Choice(['totp', 'hotp']), default='totp',
     help='Specify whether this is a time or counter-based OATH credential.')
-@click.option('-D', '--digits', type=click.Choice(['6', '8']), default='6',
+@click.option('-D', '--digits', type=click.Choice([str(d) for d in ALLOWED_DIGITS]), default=str(DEFAULT_DIGITS),
               callback=lambda c, p, v: int(v), help='Number of digits.')
 @click.option(
     '-H', '--hmac-algorithm', type=click.Choice(['SHA1', 'SHA256']),
@@ -159,7 +159,7 @@ def put(
         name = parsed.get('name')
         oath_type = parsed.get('type')
         hmac_algorithm = parsed.get('algorithm', 'SHA1').upper()
-        digits = int(parsed.get('digits', '6'))
+        digits = int(parsed.get('digits', DEFAULT_DIGITS))
         imf = int(parsed.get('counter', '0'))
 
     if oath_type not in ['totp', 'hotp']:
@@ -177,10 +177,10 @@ def put(
         # URI to contain a 'digits' value of '5'.
         digits = 6
 
-    if digits not in [6, 8]:
+    if digits not in ALLOWED_DIGITS:
         ctx.fail('Invalid number of digits for OTP')
 
-    digits = digits or 6
+    digits = digits or DEFAULT_DIGITS
     unpadded = key.upper()
     key = b32decode(unpadded + '=' * (-len(unpadded) % 8))
 

--- a/yubioath/cli/__main__.py
+++ b/yubioath/cli/__main__.py
@@ -30,7 +30,7 @@ from __future__ import print_function
 
 from .. import __version__
 from ..core.ccid import open_scard
-from ..core.standard import DEFAULT_DIGITS, ALLOWED_DIGITS, ALG_SHA1, ALG_SHA256, TYPE_HOTP, TYPE_TOTP
+from ..core.constants import DEFAULT_DIGITS, ALLOWED_DIGITS, ALG_SHA1, ALG_SHA256, TYPE_HOTP, TYPE_TOTP
 from ..core.utils import parse_uri
 from ..core.exc import NoSpaceError
 from .keystore import get_keystore

--- a/yubioath/core/constants.py
+++ b/yubioath/core/constants.py
@@ -24,49 +24,49 @@
 # non-source form of such a combination shall include the source code
 # for the parts of OpenSSL used as well as that of the covered work.
 
-from .constants import DEFAULT_DIGITS
-from .exc import CardError, InvalidSlotError, NeedsTouchError
-from .utils import (format_code, parse_full, time_challenge)
+YKOATH_AID = b'\xa0\x00\x00\x05\x27\x21\x01\x01'
+YKOATH_NO_SPACE = 0x6a84
 
-YKLEGACY_AID = b'\xa0\x00\x00\x05\x27\x20\x01'
+INS_PUT = 0x01
+INS_DELETE = 0x02
+INS_SET_CODE = 0x03
+INS_RESET = 0x04
+INS_LIST = 0xa1
+INS_CALCULATE = 0xa2
+INS_VALIDATE = 0xa3
+INS_CALC_ALL = 0xa4
+INS_SEND_REMAINING = 0xa5
 
-INS_CHALRESP = 0x01
+RESP_MORE_DATA = 0x61
 
-SLOTS = [
-    -1,
-    0x30,
-    0x38
-]
+TAG_NAME = 0x71
+TAG_NAME_LIST = 0x72
+TAG_KEY = 0x73
+TAG_CHALLENGE = 0x74
+TAG_RESPONSE = 0x75
+TAG_T_RESPONSE = 0x76
+TAG_NO_RESPONSE = 0x77
+TAG_PROPERTY = 0x78
+TAG_VERSION = 0x79
+TAG_IMF = 0x7a
+TAG_ALGO = 0x7b
+TAG_TOUCH_RESPONSE = 0x7c
 
+TYPE_MASK = 0xf0
+TYPE_HOTP = 0x10
+TYPE_TOTP = 0x20
 
-class LegacyOathCcid(object):
+DEFAULT_DIGITS = 6
+ALLOWED_DIGITS = [6, 7, 8]
 
-    """
-    CCID interface to a legacy OATH-enabled YubiKey.
-    """
+ALG_MASK = 0x0f
+ALG_SHA1 = 0x01
+ALG_SHA256 = 0x02
 
-    def __init__(self, device):
-        self._device = device
+PROP_ALWAYS_INC = 0x01
+PROP_REQUIRE_TOUCH = 0x02
 
-        self._select()
+SCHEME_STANDARD = 0x00
+SCHEME_STEAM = 0x01
 
-    def _send(self, ins, data='', p1=0, p2=0, expected=0x9000):
-        resp, status = self._device.send_apdu(0, ins, p1, p2, data)
-        if expected != status:
-            raise CardError(status)
-        return resp
-
-    def _select(self):
-        self._send(0xa4, YKLEGACY_AID, p1=0x04)
-
-    def calculate(self, slot, digits=DEFAULT_DIGITS, timestamp=None, mayblock=0):
-        data = time_challenge(timestamp)
-        try:
-            resp = self._send(INS_CHALRESP, data, p1=SLOTS[slot])
-        except CardError as e:
-            if e.status == 0x6985:
-                raise NeedsTouchError()
-            raise
-        if not resp:
-            raise InvalidSlotError()
-        return format_code(parse_full(resp), digits)
+STEAM_CHAR_TABLE = "23456789BCDFGHJKMNPQRTVWXY"

--- a/yubioath/core/legacy_ccid.py
+++ b/yubioath/core/legacy_ccid.py
@@ -24,6 +24,7 @@
 # non-source form of such a combination shall include the source code
 # for the parts of OpenSSL used as well as that of the covered work.
 
+from .standard import DEFAULT_DIGITS
 from .exc import CardError, InvalidSlotError, NeedsTouchError
 from .utils import (format_code, parse_full, time_challenge)
 
@@ -58,7 +59,7 @@ class LegacyOathCcid(object):
     def _select(self):
         self._send(0xa4, YKLEGACY_AID, p1=0x04)
 
-    def calculate(self, slot, digits=6, timestamp=None, mayblock=0):
+    def calculate(self, slot, digits=DEFAULT_DIGITS, timestamp=None, mayblock=0):
         data = time_challenge(timestamp)
         try:
             resp = self._send(INS_CHALRESP, data, p1=SLOTS[slot])

--- a/yubioath/core/legacy_otp.py
+++ b/yubioath/core/legacy_otp.py
@@ -27,7 +27,7 @@
 from __future__ import print_function
 
 from .utils import time_challenge, parse_full, format_code
-from .standard import DEFAULT_DIGITS, TYPE_TOTP
+from .constants import DEFAULT_DIGITS, TYPE_TOTP
 from .exc import InvalidSlotError, NeedsTouchError
 from yubioath.yubicommon.ctypes import CLibrary
 from hashlib import sha1

--- a/yubioath/core/legacy_otp.py
+++ b/yubioath/core/legacy_otp.py
@@ -27,7 +27,7 @@
 from __future__ import print_function
 
 from .utils import time_challenge, parse_full, format_code
-from .standard import TYPE_TOTP
+from .standard import DEFAULT_DIGITS, TYPE_TOTP
 from .exc import InvalidSlotError, NeedsTouchError
 from yubioath.yubicommon.ctypes import CLibrary
 from hashlib import sha1
@@ -125,7 +125,7 @@ class LegacyOathOtp(object):
             bool(tl & CONFIG2_VALID == CONFIG2_VALID)
         )
 
-    def calculate(self, slot, digits=6, timestamp=None, mayblock=0):
+    def calculate(self, slot, digits=DEFAULT_DIGITS, timestamp=None, mayblock=0):
         challenge = time_challenge(timestamp)
         resp = create_string_buffer(64)
         status = ykpers.yk_challenge_response(

--- a/yubioath/core/standard.py
+++ b/yubioath/core/standard.py
@@ -26,6 +26,7 @@
 
 from __future__ import print_function, division
 
+from .constants import *
 from .exc import CardError, DeviceLockedError, NoSpaceError
 from .utils import (
     der_read, der_pack, hmac_sha1, derive_key, get_random_bytes,
@@ -34,53 +35,6 @@ from yubioath.yubicommon.compat import int2byte, byte2int
 import hashlib
 import struct
 import os
-
-YKOATH_AID = b'\xa0\x00\x00\x05\x27\x21\x01\x01'
-YKOATH_NO_SPACE = 0x6a84
-
-INS_PUT = 0x01
-INS_DELETE = 0x02
-INS_SET_CODE = 0x03
-INS_RESET = 0x04
-INS_LIST = 0xa1
-INS_CALCULATE = 0xa2
-INS_VALIDATE = 0xa3
-INS_CALC_ALL = 0xa4
-INS_SEND_REMAINING = 0xa5
-
-RESP_MORE_DATA = 0x61
-
-TAG_NAME = 0x71
-TAG_NAME_LIST = 0x72
-TAG_KEY = 0x73
-TAG_CHALLENGE = 0x74
-TAG_RESPONSE = 0x75
-TAG_T_RESPONSE = 0x76
-TAG_NO_RESPONSE = 0x77
-TAG_PROPERTY = 0x78
-TAG_VERSION = 0x79
-TAG_IMF = 0x7a
-TAG_ALGO = 0x7b
-TAG_TOUCH_RESPONSE = 0x7c
-
-TYPE_MASK = 0xf0
-TYPE_HOTP = 0x10
-TYPE_TOTP = 0x20
-
-DEFAULT_DIGITS = 6
-ALLOWED_DIGITS = [6, 7, 8]
-
-ALG_MASK = 0x0f
-ALG_SHA1 = 0x01
-ALG_SHA256 = 0x02
-
-PROP_ALWAYS_INC = 0x01
-PROP_REQUIRE_TOUCH = 0x02
-
-SCHEME_STANDARD = 0x00
-SCHEME_STEAM = 0x01
-
-STEAM_CHAR_TABLE = "23456789BCDFGHJKMNPQRTVWXY"
 
 
 def format_code_steam(int_data, digits):

--- a/yubioath/core/standard.py
+++ b/yubioath/core/standard.py
@@ -67,6 +67,9 @@ TYPE_MASK = 0xf0
 TYPE_HOTP = 0x10
 TYPE_TOTP = 0x20
 
+DEFAULT_DIGITS = 6
+ALLOWED_DIGITS = [6, 7, 8]
+
 ALG_MASK = 0x0f
 ALG_SHA1 = 0x01
 ALG_SHA256 = 0x02
@@ -312,7 +315,7 @@ class YubiOathCcid(object):
         results.sort(key=lambda a: a[0].name.lower())
         return results
 
-    def put(self, name, key, oath_type=TYPE_TOTP, algo=ALG_SHA1, digits=6,
+    def put(self, name, key, oath_type=TYPE_TOTP, algo=ALG_SHA1, digits=DEFAULT_DIGITS,
             imf=0, always_increasing=False, require_touch=False):
         ensure_unlocked(self)
         key = hmac_shorten_key(key, algo)

--- a/yubioath/core/utils.py
+++ b/yubioath/core/utils.py
@@ -27,6 +27,7 @@
 from __future__ import print_function
 
 from yubioath.yubicommon.compat import int2byte, byte2int
+# can't! circular dep # from .standard import DEFAULT_DIGITS
 from Crypto.Hash import HMAC, SHA
 from Crypto.Protocol.KDF import PBKDF2
 from Crypto.Random import get_random_bytes

--- a/yubioath/core/utils.py
+++ b/yubioath/core/utils.py
@@ -27,7 +27,7 @@
 from __future__ import print_function
 
 from yubioath.yubicommon.compat import int2byte, byte2int
-# can't! circular dep # from .standard import DEFAULT_DIGITS
+from .constants import DEFAULT_DIGITS
 from Crypto.Hash import HMAC, SHA
 from Crypto.Protocol.KDF import PBKDF2
 from Crypto.Random import get_random_bytes
@@ -72,7 +72,7 @@ def parse_truncated(resp):
     return struct.unpack('>I', resp)[0] & 0x7fffffff
 
 
-def format_code(code, digits=6):
+def format_code(code, digits=DEFAULT_DIGITS):
     return ('%%0%dd' % digits) % (code % 10 ** digits)
 
 

--- a/yubioath/gui/messages.py
+++ b/yubioath/gui/messages.py
@@ -118,7 +118,7 @@ qr_not_supported_desc = "This credential type is not supported for slot " \
 qr_invalid_type = "Invalid OTP type"
 qr_invalid_type_desc = "Only TOTP and HOTP types are supported."
 qr_invalid_digits = "Invalid number of digits"
-qr_invalid_digits_desc = "An OTP may only contain 6 or 8 digits."
+qr_invalid_digits_desc = "An OTP may only contain 6, 7, or 8 digits."
 qr_invalid_algo = "Unsupported algorithm"
 qr_invalid_algo_desc = "SHA1 and SHA256 are the only supported OTP " \
     "algorithms at this time."

--- a/yubioath/gui/view/add_cred.py
+++ b/yubioath/gui/view/add_cred.py
@@ -25,7 +25,7 @@
 # for the parts of OpenSSL used as well as that of the covered work.
 
 from yubioath.yubicommon import qt
-from ...core.standard import ALG_SHA1, ALG_SHA256, TYPE_TOTP, TYPE_HOTP
+from ...core.standard import ALLOWED_DIGITS, ALG_SHA1, ALG_SHA256, TYPE_TOTP, TYPE_HOTP
 from ...core.utils import parse_uri
 from .. import messages as m
 from ..qrparse import parse_qr_codes
@@ -96,7 +96,7 @@ class AddCredDialog(qt.Dialog):
         self._cred_totp.setChecked(True)
 
         self._n_digits = QtGui.QComboBox()
-        self._n_digits.addItems(['6', '8'])
+        self._n_digits.addItems([str(d) for d in ALLOWED_DIGITS])
         layout.addRow(m.n_digits, self._n_digits)
 
         self._algorithm = QtGui.QComboBox()
@@ -142,7 +142,7 @@ class AddCredDialog(qt.Dialog):
                     m.qr_invalid_type,
                     m.qr_invalid_type_desc)
                 return
-            if n_digits not in ['6', '8']:
+            if n_digits not in [str(d) for d in ALLOWED_DIGITS]:
                 QtGui.QMessageBox.warning(
                     self,
                     m.qr_invalid_digits,

--- a/yubioath/gui/view/add_cred.py
+++ b/yubioath/gui/view/add_cred.py
@@ -25,7 +25,7 @@
 # for the parts of OpenSSL used as well as that of the covered work.
 
 from yubioath.yubicommon import qt
-from ...core.standard import ALLOWED_DIGITS, ALG_SHA1, ALG_SHA256, TYPE_TOTP, TYPE_HOTP
+from ...core.constants import ALLOWED_DIGITS, ALG_SHA1, ALG_SHA256, TYPE_TOTP, TYPE_HOTP
 from ...core.utils import parse_uri
 from .. import messages as m
 from ..qrparse import parse_qr_codes

--- a/yubioath/gui/view/add_cred_legacy.py
+++ b/yubioath/gui/view/add_cred_legacy.py
@@ -29,6 +29,7 @@ from .add_cred import B32Validator
 from .. import messages as m
 from ..qrparse import parse_qr_codes
 from ..qrdecode import decode_qr_data
+from ...core.standard import ALLOWED_DIGITS
 from ...core.utils import parse_uri
 from PySide import QtGui
 from base64 import b32decode
@@ -72,7 +73,7 @@ class AddCredDialog(qt.Dialog):
         layout.addRow(self._touch)
 
         self._n_digits = QtGui.QComboBox()
-        self._n_digits.addItems(['6', '8'])
+        self._n_digits.addItems([str(d) for d in ALLOWED_DIGITS])
         layout.addRow(m.n_digits, self._n_digits)
 
         btns = QtGui.QDialogButtonBox(QtGui.QDialogButtonBox.Ok |

--- a/yubioath/gui/view/add_cred_legacy.py
+++ b/yubioath/gui/view/add_cred_legacy.py
@@ -29,7 +29,7 @@ from .add_cred import B32Validator
 from .. import messages as m
 from ..qrparse import parse_qr_codes
 from ..qrdecode import decode_qr_data
-from ...core.standard import ALLOWED_DIGITS
+from ...core.constants import ALLOWED_DIGITS
 from ...core.utils import parse_uri
 from PySide import QtGui
 from base64 import b32decode

--- a/yubioath/gui/view/codes.py
+++ b/yubioath/gui/view/codes.py
@@ -26,7 +26,7 @@
 
 from PySide import QtGui, QtCore
 from .. import messages as m
-from ...core.standard import TYPE_HOTP
+from ...core.constants import TYPE_HOTP
 from yubioath.yubicommon.qt.utils import connect_once
 from time import time
 

--- a/yubioath/gui/view/settings.py
+++ b/yubioath/gui/view/settings.py
@@ -26,7 +26,7 @@
 
 from yubioath.yubicommon import qt
 from .. import messages as m
-from ...core.standard import ALLOWED_DIGITS
+from ...core.constants import ALLOWED_DIGITS
 from PySide import QtGui
 
 INDENT = 16

--- a/yubioath/gui/view/settings.py
+++ b/yubioath/gui/view/settings.py
@@ -26,6 +26,7 @@
 
 from yubioath.yubicommon import qt
 from .. import messages as m
+from ...core.standard import ALLOWED_DIGITS
 from PySide import QtGui
 
 INDENT = 16
@@ -51,7 +52,7 @@ class SettingsDialog(qt.Dialog):
         self._slot1_enabled.setToolTip(m.tt_slot_enabled_1 % 1)
         layout.addRow(self._slot1_enabled)
         self._slot1_digits = QtGui.QComboBox()
-        self._slot1_digits.addItems(['6', '8'])
+        self._slot1_digits.addItems([str(d) for d in ALLOWED_DIGITS])
         self._slot1_enabled.stateChanged.connect(self._slot1_digits.setEnabled)
         self._slot1_digits.setEnabled(False)
         self._slot1_digits.setToolTip(m.tt_num_digits)
@@ -63,7 +64,7 @@ class SettingsDialog(qt.Dialog):
         self._slot2_enabled.setToolTip(m.tt_slot_enabled_1 % 2)
         layout.addRow(self._slot2_enabled)
         self._slot2_digits = QtGui.QComboBox()
-        self._slot2_digits.addItems(['6', '8'])
+        self._slot2_digits.addItems([str(d) for d in ALLOWED_DIGITS])
         self._slot2_enabled.stateChanged.connect(self._slot2_digits.setEnabled)
         self._slot2_digits.setEnabled(False)
         self._slot2_digits.setToolTip(m.tt_num_digits)


### PR DESCRIPTION
I would like to generate TOTP codes for a service that uses 7 digits. This adds that possibility, and moves both the default # of digits and allowed set (now [6, 7, 8]) to constants, which are moved to their own file to avoid a circular import problem.

I've tried this on a YubiKey 4 Nano, and the YubiKey has no problem storing the configuration, and in fact an unpatched version of the `yubioath` command will now output 7 digits for my test credential; the number-of-digits validation happens at the time you run `put`, so this makes sense.