### PR TITLE
some UX fixes

### DIFF
--- a/qml/MainMenuBar.qml
+++ b/qml/MainMenuBar.qml
@@ -38,7 +38,7 @@ MenuBar {
             onTriggered: openSettings()
         }
         MenuItem {
-            text: qsTr("\&Exit")
+            text: qsTr("E\&xit")
             onTriggered: Qt.quit()
             shortcut: StandardKey.Quit
         }

--- a/qml/PasswordPrompt.qml
+++ b/qml/PasswordPrompt.qml
@@ -48,6 +48,7 @@ DefaultDialog {
             Button {
                 id: okBtn
                 text: qsTr("Ok")
+                isDefault: true
                 Layout.alignment: Qt.AlignRight | Qt.AlignBottom
                 onClicked: promptAccepted()
                 KeyNavigation.tab: cancelBtn

--- a/qml/YubiKey.qml
+++ b/qml/YubiKey.qml
@@ -87,7 +87,7 @@ Python {
 
     function refreshCCIDCredentials(force) {
         var now = Math.floor(Date.now() / 1000)
-        if (force || (validated && nextRefresh < now)) {
+        if (force || (validated && nextRefresh <= now)) {
             do_call('yubikey.controller.refresh_credentials',
                     [now, passwordKey], updateAllCredentials)
             return true;
@@ -97,7 +97,7 @@ Python {
 
     function refreshSlotCredentials(slots, digits, force) {
         var now = Math.floor(Date.now() / 1000)
-        if (force || (nextRefresh < now)) {
+        if (force || (nextRefresh <= now)) {
             do_call('yubikey.controller.refresh_slot_credentials',
                     [slots, digits, now], updateAllCredentials)
             return true;

--- a/qml/YubiKey.qml
+++ b/qml/YubiKey.qml
@@ -90,7 +90,9 @@ Python {
         if (force || (validated && nextRefresh < now)) {
             do_call('yubikey.controller.refresh_credentials',
                     [now, passwordKey], updateAllCredentials)
+            return true;
         }
+        return false;
     }
 
     function refreshSlotCredentials(slots, digits, force) {
@@ -98,7 +100,9 @@ Python {
         if (force || (nextRefresh < now)) {
             do_call('yubikey.controller.refresh_slot_credentials',
                     [slots, digits, now], updateAllCredentials)
+            return true;
         }
+        return false;
     }
 
     function validate(providedPassword, cb) {

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -307,6 +307,10 @@ ApplicationWindow {
                 sequence: StandardKey.Find
                 onActivated: search.focus = true
             }
+            Shortcut {
+                sequence: StandardKey.Cancel
+                onActivated: search.text = qsTr("")
+            }
         }
     }
 

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -60,6 +60,16 @@ ApplicationWindow {
 
     Component.onDestruction: saveScreenLayout()
 
+    onClosing: {
+        ykTimer.running = false
+        timeLeftTimer.running = false
+    }
+
+    onActiveChanged: {
+        ykTimer.running = appWindow.visible
+        timeLeftTimer.running = appWindow.visible
+    }
+
     Shortcut {
         sequence: StandardKey.Close
         onActivated: close()

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -16,6 +16,7 @@ ApplicationWindow {
     title: getTitle()
     property var device: yk
     property var credentials: device.credentials
+    property bool isRefreshing: false
     property bool hasDevice: device.hasDevice
     property bool canShowCredentials: device.hasDevice && modeAndKeyMatch
                                       && device.validated
@@ -167,6 +168,9 @@ ApplicationWindow {
         onError: console.log(traceback)
         onWrongPassword: passwordPrompt.open()
         onCredentialsRefreshed: {
+            var timeLeft = device.expiration - (Date.now() / 1000)
+            timeLeftBar.value = timeLeft
+            isRefreshing = false
             flickable.restoreScrollPosition()
             hotpTouchTimer.stop()
             touchYourYubikey.close()
@@ -287,7 +291,7 @@ ApplicationWindow {
                                     color: getCredentialTextColor(modelData)
                                 }
                                 Label {
-                                    opacity: isExpired(modelData) ? 0.6 : 1
+                                    opacity: isRefreshing ? 0.6 : 1
                                     visible: modelData.code !== null
                                     text: qsTr("") + modelData.code
                                     font.pixelSize: 20
@@ -370,11 +374,11 @@ ApplicationWindow {
 
     function checkTimeLeft() {
         var timeLeft = device.expiration - (Date.now() / 1000)
+        timeLeftBar.value = timeLeft
         if (timeLeft <= 0 && timeLeftBar.value > 0) {
             flickable.saveScrollPosition()
             refreshDependingOnMode(true)
         }
-        timeLeftBar.value = timeLeft
     }
 
     function allowManualGenerate(cred) {
@@ -408,10 +412,10 @@ ApplicationWindow {
     function refreshDependingOnMode(force) {
         if (hasDevice && shouldRefresh) {
             if (settings.slotMode && device.hasOTP) {
-                device.refreshSlotCredentials([settings.slot1, settings.slot2],
-                                              getSlotDigitsSettings(), force)
+                isRefreshing = device.refreshSlotCredentials([settings.slot1, settings.slot2],
+                                                             getSlotDigitsSettings(), force)
             } else if (!settings.slotMode && device.hasCCID) {
-                device.refreshCCIDCredentials(force)
+                isRefreshing = device.refreshCCIDCredentials(force)
             }
         }
     }


### PR DESCRIPTION
This fixes some of the UX issues raised in #149.

Issues mentioned there that **ARE** fixed by this pull request:
* The File>Exit menu item should either be "E&xit" or "&Quit" (i.e. the keyboard shortcut should be x or q, as with any other app, but not "&Exit" as it currently is).
* When the search text box has focus, I'd expect the Escape key to clear the current search terms (muscle memory from using search in web browsers like Chrome or Firefox)

Other issues fixed in this pull request:
* The timers are suspended when the window is not visible (i.e. minimized to system tray). They resume as soon as the window is opened again.
* Credentials were being refreshed one second *after* the deadline instead of *on* the deadline.
* Progress bar color now is pulled from SystemPalette.highlight

Issues mentioned there that **ARE NOT** fixed by this pull request:
* The "enter" key does nothing in the passphrase dialog when the checkbox has focus (i.e. enter passphrase, tab to checkbox, space to check it, pressing enter should click OK as it does when the text box has focus, but it does not)

Issues discovered during creation of this pull rquest:
* Double-clicking the tray icon doesn't show the window (#150)

(Amended: I changed my mind about the progress bar update timer tick. As long as the timer is stopped while the app is in the tray, it shouldn't have any appreciable impact on battery life.)