### PR TITLE
qrdecode: fix infinite loop when encoding type is 1 (numeric)

### DIFF
--- a/py/qr/qrdecode.py
+++ b/py/qr/qrdecode.py
@@ -223,11 +223,15 @@ def parse_bits(bits, version):
         while l > 0:
             if l >= 3:
                 num, bits = bits_to_int(bits[:10]), bits[10:]
+                l -= 3
             elif l >= 2:
                 num, bits = bits_to_int(bits[:7]), bits[7:]
+                l -= 2
             else:
                 num, bits = bits_to_int(bits[:3]), bits[3:]
+                l -= 1
             buf += str(num)
+        return buf, bits
     elif enc == 2:  # Alphanumeric
         n_l = 9 if version < 10 else 11 if version < 27 else 13
         l, bits = bits_to_int(bits[:n_l]), bits[n_l:]


### PR DESCRIPTION
Found a bug in the QR decoder when doing code coverage testing of my PyQt5 port for v3.x. I managed to find a QR code that got the interpreter into an infinite loop.

See the QR code near the bottom of this page, under the heading "Supported Barcode Types": https://packagist.org/packages/yellowskies/qr-code-bundle

