### PR TITLE
Apply alternateBase color to progress bar background

### DIFF
--- a/qml/TimeLeftBar.qml
+++ b/qml/TimeLeftBar.qml
@@ -12,4 +12,9 @@ ProgressBar {
     maximumValue: 30
     minimumValue: 0
     rotation: 180
+    style: ProgressBarStyle {
+        background: Rectangle {
+            color: palette.alternateBase
+        }
+    }
 }


### PR DESCRIPTION
The background color for the progress bar is black on fedora, which makes it difficult to read time remaining:
![screenshot from 2017-10-20 16-55-52](https://user-images.githubusercontent.com/5983112/31843377-3a1b669c-b5b8-11e7-9046-f1543681bba1.png)
This PR sets the progress bar background to the alternate base color, which improves readability significantly without requiring a color be selected for the foreground:
![screenshot from 2017-10-20 16-55-11](https://user-images.githubusercontent.com/5983112/31843410-642be6b4-b5b8-11e7-9f37-0df96082c24f.png)
