### PR TITLE
Add option to hide window on launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ qrc_*.cpp
 moc_*.cpp
 moc_*.h
 yubioath-desktop.app/
+yubioath-desktop
 pymodules
 .vagrant/

--- a/main.cpp
+++ b/main.cpp
@@ -94,6 +94,11 @@ int main(int argc, char *argv[])
 
     // Set icon in the window, doesn't effect desktop icons.
     qmlWindow->setIcon(QIcon(path_prefix + "/images/windowicon.png"));
+    // Show root window unless explicitly hidden in settings.
+    auto hideOnLaunch = qmlWindow->property("hideOnLaunch");
+    if (!hideOnLaunch.toBool()) {
+        qmlWindow->show();
+    }
 
     QAction *showAction = new QAction(QObject::tr("&Show credentials"), qmlWindow);
     // The call to hide doesn't make much sense but makes it work on macOS when hidden from the dock.

--- a/qml/SettingsDialog.qml
+++ b/qml/SettingsDialog.qml
@@ -15,6 +15,7 @@ DefaultDialog {
     property alias slot1digits: slot1digits.currentIndex
     property alias slot2digits: slot2digits.currentIndex
     property alias closeToTray: closeToTray.checked
+    property alias hideOnLaunch: hideOnLaunch.checked
 
     ColumnLayout {
         anchors.fill: parent
@@ -97,6 +98,23 @@ DefaultDialog {
             CheckBox {
                 id: closeToTray
                 checked: settings.closeToTray
+                onCheckedChanged: {
+                    if (!checked) {
+                        hideOnLaunch.checked = false
+                    }
+                }
+                KeyNavigation.tab: saveSettingsBtn
+                Keys.onEscapePressed: close()
+            }
+            Label {
+                text: qsTr("Hide on launch")
+                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                Layout.fillWidth: false
+            }
+            CheckBox {
+                id: hideOnLaunch
+                enabled: closeToTray.checked
+                checked: settings.hideOnLaunch
                 KeyNavigation.tab: saveSettingsBtn
                 Keys.onEscapePressed: close()
             }

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -12,7 +12,6 @@ ApplicationWindow {
     height: 400
     minimumHeight: 400
     minimumWidth: 300
-    visible: true
     title: getTitle()
     property var device: yk
     property var credentials: device.credentials
@@ -30,6 +29,8 @@ ApplicationWindow {
     // Don't refresh credentials when window is minimized or hidden
     // See http://doc.qt.io/qt-5/qwindow.html#Visibility-enum
     property bool shouldRefresh: visibility != 3 && visibility != 0
+
+    property bool hideOnLaunch: settings.hideOnLaunch
 
     signal copy
     signal generate(bool copyAfterGenerate)
@@ -88,6 +89,7 @@ ApplicationWindow {
         property var slot2digits
         property string savedPasswords
         property bool closeToTray
+        property bool hideOnLaunch
 
         // Keep track of window and desktop dimensions.
         property alias width: appWindow.width
@@ -598,6 +600,7 @@ ApplicationWindow {
         settings.slot1digits = settingsDialog.slot1digits
         settings.slot2digits = settingsDialog.slot2digits
         settings.closeToTray = settingsDialog.closeToTray
+        settings.hideOnLaunch = settingsDialog.hideOnLaunch
     }
 
     function trySetPassword() {


### PR DESCRIPTION
I typically launch yubioath-desktop when my window manager starts. Something I've always wanted to have was for the application to launch to the system tray. I was able to hack something up that works, though there are some side-effects I don't understand (I'm not very savvy when it comes to Qt).

Out of curiosity, is this something that the team might be interested in? If so, I have questions! These changes work with the exception of a bug when leaving the settings dialog if both Show in system tray and Hide on launched options are unchecked - the main window disappears. I suspect this is due to the change I made to the visible property, however I'm not sure of how to make this dynamic. Ideally we would inhibit showing the main window immediately after launch rather than when the option is checked.

Thanks in advance!

Obligatory screenshot below.
![31841929-582d1e3e-b5b1-11e7-968e-5f3aefbee19f](https://user-images.githubusercontent.com/5983112/31902410-685eef5e-b7ea-11e7-884e-b2d23abda657.png)

(Apologies for resubmitting the PR, I accidentally created this off of the master branch)
