### PR TITLE
Apply transientScrollBars style to ScrollView

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -221,6 +221,9 @@ ApplicationWindow {
 
         ScrollView {
             id: scrollView
+            style: ScrollViewStyle {
+                transientScrollBars: true
+            }
             Layout.fillHeight: true
             Layout.fillWidth: true
 


### PR DESCRIPTION
I noticed a styling quirk in Fedora today when hovering over the scrollbar in the ScrollView:
![screenshot from 2017-10-24 20-19-19](https://user-images.githubusercontent.com/5983112/31976020-8cbf10ac-b8fa-11e7-9fba-508b0c4fab95.png)
This PR enables the `transientScrollBars` style in `ScrollView` which cleans up the styling on the scrollbar without requiring that specific colors be applied:
![screenshot from 2017-10-24 20-17-55](https://user-images.githubusercontent.com/5983112/31976077-c7315d62-b8fa-11e7-95fe-28996e56c84f.png)
