### PR TITLE
Fix keyboard shortcuts from search 

### DIFF
--- a/qml/CredentialMenu.qml
+++ b/qml/CredentialMenu.qml
@@ -8,9 +8,7 @@ Menu {
     property bool enableGenerate
 
     MenuItem {
-        text: qsTr("\&Copy to clipboard")
-        enabled: (credential != null) && (credential.code != null)
-        onTriggered: copy()
+        action: copyAction
     }
 
     MenuItem {

--- a/qml/MainMenuBar.qml
+++ b/qml/MainMenuBar.qml
@@ -53,10 +53,7 @@ MenuBar {
         title: qsTr("\&Edit")
 
         MenuItem {
-            text: qsTr("\&Copy to clipboard")
-            shortcut: StandardKey.Copy
-            enabled: (getSelected() != null) && (getSelected().code != null)
-            onTriggered:copy()
+            action: copyAction
         }
 
         MenuItem {

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -329,14 +329,16 @@ ApplicationWindow {
                 onActivated: search.forceActiveFocus()
             }
             onTextChanged: selectFirstSearchResult()
-            Keys.onEscapePressed: {
-                search.clear()
-                deselectCredential()
-            }
+            Keys.onEscapePressed: search.clear()
             Keys.onReturnPressed: generateOrCopy()
             Keys.onEnterPressed: generateOrCopy()
             Keys.onDownPressed: arrowKeys.goDown()
             Keys.onUpPressed: arrowKeys.goUp()
+            function clear() {
+                search.text = ""
+                arrowKeys.forceActiveFocus()
+                deselectCredential()
+            }
         }
     }
 

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -334,12 +334,29 @@ ApplicationWindow {
             Keys.onEnterPressed: generateOrCopy()
             Keys.onDownPressed: arrowKeys.goDown()
             Keys.onUpPressed: arrowKeys.goUp()
+
+            // Override the copy action,
+            // since this is a TextField.
+            Keys.onPressed: {
+                if(event.matches(StandardKey.Copy)) {
+                    copyAction.trigger()
+                }
+            }
+
             function clear() {
                 search.text = ""
                 arrowKeys.forceActiveFocus()
                 deselectCredential()
             }
         }
+    }
+
+    Action {
+        id: copyAction
+        text: qsTr("\&Copy to clipboard")
+        shortcut: StandardKey.Copy
+        enabled: (getSelected() != null) && (getSelected().code != null)
+        onTriggered: copy()
     }
 
     Timer {

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -236,6 +236,7 @@ ApplicationWindow {
                 // outside search bar to remove focus from it.
                 anchors.fill: parent
                 onClicked: {
+                    arrowKeys.forceActiveFocus()
                     deselectCredential()
                 }
             }
@@ -286,6 +287,7 @@ ApplicationWindow {
                             onDoubleClick: {
                                 // A double-click should select the credential,
                                 // then generate if needed and copy the code.
+                                arrowKeys.forceActiveFocus()
                                 selectCredential(modelData)
                                 generateOrCopy()
                             }
@@ -293,6 +295,7 @@ ApplicationWindow {
                             onRefresh: refreshDependingOnMode(force)
 
                             onSingleClick: {
+                                arrowKeys.forceActiveFocus()
                                 // Left click, select or deselect credential.
                                 if (mouse.button & Qt.LeftButton) {
                                     if (appWindow.isSelected(modelData.credential)) {


### PR DESCRIPTION
Related to #222 .

These changes still has the search field as default focus, but allows CTRL/CMD + C to be used to copy the selected credential and re-enables ESC for clearing the search field.