### PR TITLE
Hide global progress bar when no non-touch TOTP credentials is there

### DIFF
--- a/qml/YubiKey.qml
+++ b/qml/YubiKey.qml
@@ -208,6 +208,13 @@ Python {
         return false
     }
 
+    function hasAnyNonTouchTotpCredential() {
+        return util.find(entries, function (entry) {
+            return !entry.credential.touch
+                    && entry.credential.oath_type === 'TOTP'
+        }) || false
+    }
+
     function hasAnyCredentials() {
         return entries != null && entries.length > 0
     }

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -223,7 +223,7 @@ ApplicationWindow {
 
         TimeLeftBar {
             id: timeLeftBar
-            visible: canShowCredentials && device.hasAnyCredentials()
+            visible: canShowCredentials && device.hasAnyCredentials() && device.hasAnyNonTouchTotpCredential()
         }
 
         ScrollView {


### PR DESCRIPTION
When no non-touch TOTP credential is present, there is no need to show the global progress bar. It's distracting!