### PR TITLE
Handle timeout on touch credentials better

### DIFF
--- a/qml/YubiKey.qml
+++ b/qml/YubiKey.qml
@@ -246,8 +246,12 @@ Python {
         var margin = entry.credential.touch ? 10 : 0
         do_call('yubikey.controller.calculate',
                 [entry.credential, now + margin], function (code) {
-                    updateSingleCredential(entry.credential, code,
-                                           copyAfterUpdate)
+                    if (code) {
+                        updateSingleCredential(entry.credential, code,
+                                               copyAfterUpdate)
+                    } else {
+                        touchYourYubikey.close()
+                    }
                 })
     }
 


### PR DESCRIPTION
When the user didn't touch the device on
a touch credential, the code was undefined.
Slot mode already handled this better.