### PR TITLE
Fix expiration on single touch credential

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -291,7 +291,10 @@ ApplicationWindow {
                                 generateOrCopy()
                             }
 
-                            onRefresh: refreshDependingOnMode(force)
+                            onRefresh: {
+                                refreshDependingOnMode(force)
+                                isExpired = appWindow.isExpired(modelData)
+                            }
 
                             onSingleClick: {
                                 arrowKeys.forceActiveFocus()


### PR DESCRIPTION
With a single touch credential the code would not gray out and the timer would not go away.

(This change seems to fix the issue, but there might be cleaner ways to solve this..)