### PR TITLE
Fix expiration on single touch credential, alternative solution

### DIFF
--- a/qml/CredentialItem.qml
+++ b/qml/CredentialItem.qml
@@ -17,8 +17,8 @@ Rectangle {
     readonly property bool hasCustomTimeBar: (code
                                               && ((credential.period
                                                    && credential.period !== 30)
-                                                  || (credential.touch
-                                                      && !isExpired)))
+                                                  || credential.touch))
+    readonly property bool showCustomTimeBar: hasCustomTimeBar && !isExpired
     readonly property bool isExpired: timeLeft <= 0
     readonly property color textColor: (isSelected ? palette.highlightedText : palette.windowText)
 
@@ -77,7 +77,7 @@ Rectangle {
         ProgressBar {
             id: customTimeLeftBar
             value: timeLeft / 1000
-            visible: hasCustomTimeBar
+            visible: showCustomTimeBar
             Layout.topMargin: 3
             Layout.fillWidth: true
             Layout.minimumHeight: 7

--- a/qml/CredentialItem.qml
+++ b/qml/CredentialItem.qml
@@ -5,7 +5,6 @@ import QtQuick.Layouts 1.1
 Rectangle {
     property var code
     property var credential
-    property bool isExpired: true
     property bool isSelected: false
     property int timeLeft: 0
     property bool timerRunning: false
@@ -20,6 +19,7 @@ Rectangle {
                                                    && credential.period !== 30)
                                                   || (credential.touch
                                                       && !isExpired)))
+    readonly property bool isExpired: timeLeft < 0
     readonly property color textColor: (isSelected ? palette.highlightedText : palette.windowText)
 
     color: (isSelected ? palette.highlight : unselectedColor)

--- a/qml/CredentialItem.qml
+++ b/qml/CredentialItem.qml
@@ -19,7 +19,7 @@ Rectangle {
                                                    && credential.period !== 30)
                                                   || (credential.touch
                                                       && !isExpired)))
-    readonly property bool isExpired: timeLeft < 0
+    readonly property bool isExpired: timeLeft <= 0
     readonly property color textColor: (isSelected ? palette.highlightedText : palette.windowText)
 
     color: (isSelected ? palette.highlight : unselectedColor)

--- a/qml/CredentialItem.qml
+++ b/qml/CredentialItem.qml
@@ -7,6 +7,7 @@ Rectangle {
     property var credential
     property bool isExpired: true
     property bool isSelected: false
+    property int timeLeft: 0
     property bool timerRunning: false
     property color unselectedColor
 
@@ -67,15 +68,15 @@ Rectangle {
             running: timerRunning && hasCustomTimeBar
             triggeredOnStart: true
             onTriggered: {
-                var timeLeft = code.valid_to - (Date.now() / 1000)
+                timeLeft = code.valid_to * 1000 - Date.now()
                 if (timeLeft <= 0 && customTimeLeftBar.value > 0) {
                     refresh(true)
                 }
-                customTimeLeftBar.value = timeLeft
             }
         }
         ProgressBar {
             id: customTimeLeftBar
+            value: timeLeft / 1000
             visible: hasCustomTimeBar
             Layout.topMargin: 3
             Layout.fillWidth: true

--- a/qml/CredentialItem.qml
+++ b/qml/CredentialItem.qml
@@ -76,7 +76,7 @@ Rectangle {
         }
         ProgressBar {
             id: customTimeLeftBar
-            value: timeLeft / 1000
+            value: Math.min(timeLeft / 1000, credential.period)
             visible: showCustomTimeBar
             Layout.topMargin: 3
             Layout.fillWidth: true

--- a/qml/CredentialItem.qml
+++ b/qml/CredentialItem.qml
@@ -19,7 +19,7 @@ Rectangle {
                                                    && credential.period !== 30)
                                                   || credential.touch))
     readonly property bool showCustomTimeBar: hasCustomTimeBar && !isExpired
-    readonly property bool isExpired: timeLeft <= 0
+    readonly property bool isExpired: timeLeft < 0
     readonly property color textColor: (isSelected ? palette.highlightedText : palette.windowText)
 
     color: (isSelected ? palette.highlight : unselectedColor)

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -277,7 +277,6 @@ ApplicationWindow {
                         CredentialItem {
                             code: modelData.code
                             credential: modelData.credential
-                            isExpired: appWindow.isExpired(modelData)
                             isSelected: appWindow.isSelected(
                                             modelData.credential)
                             timerRunning: displayTimersRunning


### PR DESCRIPTION
This feels like a cleaner solution than #250.

Basically it seems like the QML engine doesn't detect that the value of the expression `appWindow.isExpired(modelData)` could have changed, because it's not a functionally pure expression. If we instead base the property bindings on a property containing the current time, and imperatively update the time property instead, that should solve the issue.

We might want to consider extracting a "current time" property like this up to the top level and base all time based computations off that instead of `Date.now()`.