### PR TITLE
Add shim for String.prototype.startsWith

### DIFF
--- a/qml/YubiKey.qml
+++ b/qml/YubiKey.qml
@@ -62,7 +62,7 @@ Python {
     }
 
     function isPythonReady(funcName) {
-        if (funcName.startsWith("yubikey.init")) {
+        if (Utils.startsWith(funcName, "yubikey.init")) {
             return yubikeyModuleLoaded
         } else {
             return yubikeyReady

--- a/qml/utils.js
+++ b/qml/utils.js
@@ -12,6 +12,12 @@ function versionGE(version, major, minor, micro) {
     return false
 }
 
+// Shim for String.prototype.startsWith(), added in Qt 5.8
+// Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
+function startsWith(string, search, pos) {
+    return string.substr(!pos || pos < 0 ? 0 : +pos, search.length) === search
+}
+
 /*
  * Quick and dirty shim for Array.find added in Qt 5.9
  *


### PR DESCRIPTION
Without this, on Ubuntu Xenial we get `qrc:///qml/YubiKey.qml:65: TypeError: Property 'startsWith' of object yubikey.controller.count_devices is not a function`. 