### PR TITLE
Make Windows version tweaking work with X.Y.Z-C-gCOMMIT[-dirty] version strings

### DIFF
--- a/yubioath-desktop.pro
+++ b/yubioath-desktop.pro
@@ -21,13 +21,11 @@ DEFINES += APP_VERSION=\\\"$$VERSION\\\"
 
 win32|win64 {
   # Strip suffixes from version number
-  # Append ".0" if "-dirty"
-  # Otherwise if suffix starts with "-X", where X is numeric, replace suffix with ".X"
-  # Otherwise replace suffix with ".1"
   # Because rc compiler requires only numerals in the version number
-  VERSION ~= s/^([0-9]+\.[0-9]+\.[0-9]+).*-dirty$/\1.0
-  VERSION ~= s/^([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+).*/\1.\2
-  VERSION ~= s/^([0-9]+\.[0-9]+\.[0-9]+)$/\1.1
+  # If version contains "-", output version (0, 0, 0, 0)
+  # Otherwise assume version is "X.Y.Z", where X, Y, Z are all numeric. Output version (X, Y, Z, 0).
+  VERSION ~= s/^.*-.*$/0.0.0.0
+  VERSION ~= s/^([0-9]+\.[0-9]+\.[0-9]+)$/\1.0
   message(Version tweaked for Windows build: $$VERSION)
 }
 

--- a/yubioath-desktop.pro
+++ b/yubioath-desktop.pro
@@ -21,10 +21,13 @@ DEFINES += APP_VERSION=\\\"$$VERSION\\\"
 
 win32|win64 {
   # Strip suffixes from version number
-  # Append ".0" if "-dirty" or append ".1" if not "-dirty"
+  # Append ".0" if "-dirty"
+  # Otherwise if suffix starts with "-X", where X is numeric, replace suffix with ".X"
+  # Otherwise replace suffix with ".1"
   # Because rc compiler requires only numerals in the version number
   VERSION ~= s/^([0-9]+\.[0-9]+\.[0-9]+).*-dirty$/\1.0
-  VERSION ~= s/^([0-9]+\.[0-9]+\.[0-9]+)(-.*)?/\1.1
+  VERSION ~= s/^([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+).*/\1.\2
+  VERSION ~= s/^([0-9]+\.[0-9]+\.[0-9]+)$/\1.1
   message(Version tweaked for Windows build: $$VERSION)
 }
 


### PR DESCRIPTION
Previously, the code assumed that after removing a `-dirty` suffix there will be no more than 1 `-` in the remaining string. This is not true for, for example, `4.3.2-68-gCOMMIT-dirty`. This string matched both of the substitution rules, resulting in a Windows version of `4.3.2.0.1`
instead of the intended `4.3.2.0`.