### PR TITLE
Add credential: allow space in secret key

### DIFF
--- a/qml/AddCredential.qml
+++ b/qml/AddCredential.qml
@@ -49,7 +49,7 @@ DefaultDialog {
                 id: key
                 Layout.fillWidth: true
                 validator: RegExpValidator {
-                    regExp: /[2-7a-zA-Z]+=*/
+                    regExp: /[2-7a-zA-Z ]+=*/
                 }
                 Keys.onEscapePressed: close()
                 onAccepted: tryAddCredential()

--- a/qml/AddCredentialSlot.qml
+++ b/qml/AddCredentialSlot.qml
@@ -24,9 +24,9 @@ DefaultDialog {
                 id: key
                 Layout.fillWidth: true
                 validator: RegExpValidator {
-                    regExp: /[2-7a-zA-Z]+=*/
+                    regExp: /[2-7a-zA-Z ]+=*/
                 }
-                focus:true
+                focus: true
                 Keys.onEscapePressed: close()
                 onAccepted: tryAddCredential()
             }
@@ -62,7 +62,6 @@ DefaultDialog {
             }
         }
 
-
         RowLayout {
             Layout.alignment: Qt.AlignRight | Qt.AlignBottom
             Button {
@@ -84,7 +83,6 @@ DefaultDialog {
             }
         }
     }
-
 
     MessageDialog {
         id: paddingError


### PR DESCRIPTION
Some services provide the OATH secret with spaces. Allow this in the add credential dialogs,
to allow users to copy and paste from these services.

Should fix #269 