### PR TITLE
Replace QtSingleApplication with a QLockFile

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/qt-solutions"]
-	path = vendor/qt-solutions
-	url = https://github.com/qtproject/qt-solutions

--- a/main.cpp
+++ b/main.cpp
@@ -18,7 +18,18 @@ int main(int argc, char *argv[])
     // Don't write .pyc files.
     qputenv("PYTHONDONTWRITEBYTECODE", "1");
 
+    QString tmpDir = QDir::tempPath();
+    QLockFile lockFile(tmpDir + "/yubioath-desktop.lock");
     QApplication app(argc, argv);
+
+    if(!lockFile.tryLock(100)){
+        QMessageBox msgBox;
+        msgBox.setIcon(QMessageBox::Warning);
+        msgBox.setText("Yubico Authenticator is already running."
+                        "\r\nOnly one instance is allowed.");
+        msgBox.exec();
+        return 1;
+    }
 
     QString app_dir = app.applicationDirPath();
     QString main_qml = "/qml/main.qml";

--- a/main.cpp
+++ b/main.cpp
@@ -18,15 +18,18 @@ int main(int argc, char *argv[])
     // Don't write .pyc files.
     qputenv("PYTHONDONTWRITEBYTECODE", "1");
 
+    QApplication app(argc, argv);
+    app.setApplicationName("Yubico Authenticator");
+    app.setOrganizationName("Yubico");
+    app.setOrganizationDomain("com.yubico");
+
+    // A lock file is used, to ensure only one running instance at the time.
     QString tmpDir = QDir::tempPath();
     QLockFile lockFile(tmpDir + "/yubioath-desktop.lock");
-    QApplication app(argc, argv);
-
     if(!lockFile.tryLock(100)){
         QMessageBox msgBox;
         msgBox.setIcon(QMessageBox::Warning);
-        msgBox.setText("Yubico Authenticator is already running."
-                        "\r\nOnly one instance is allowed.");
+        msgBox.setText("Yubico Authenticator is already running.");
         msgBox.exec();
         return 1;
     }
@@ -35,10 +38,6 @@ int main(int argc, char *argv[])
     QString main_qml = "/qml/main.qml";
     QString path_prefix;
     QString url_prefix;
-
-    app.setApplicationName("Yubico Authenticator");
-    app.setOrganizationName("Yubico");
-    app.setOrganizationDomain("com.yubico");
 
     if (QFileInfo::exists(":" + main_qml)) {
         // Embedded resources

--- a/yubioath-desktop.pro
+++ b/yubioath-desktop.pro
@@ -61,11 +61,6 @@ macx {
 # Default rules for deployment.
 include(deployment.pri)
 
-# Mac doesn't use qSingleApplication
-!macx {
-    include(vendor/qt-solutions/qtsingleapplication/src/qtsingleapplication.pri)
-}
-
 # Icon file
 RC_ICONS = resources/icons/yubioath.ico
 


### PR DESCRIPTION
What:
- This PR drops the dependency on QtSingleApplication and instead uses a QLockFile to ensure that only one instance is running per user, as suggested [here](http://blog.aeguana.com/2015/10/15/how-to-run-a-single-app-instance-in-qt/). Showing a "App is already running" message seems to be a [common pattern](https://www.google.se/search?q=is+already+running&source=lnms&tbm=isch&sa=X&ved=0ahUKEwjI8930j7nZAhVEK1AKHZFHCEQQ_AUICigB&biw=1280&bih=704).

Why:
- Mostly to simplify the build process and allow us to drop the submodule. But the new behaviour should also make it a be bit more clear for the user what is going on. The previous behaviour on Windows was that the application started blinking in the start menu, but didn't actually showed itself, when the user tried to launch a new instance.