### PR TITLE
Sort qrc input file list

### DIFF
--- a/build_qrc.py
+++ b/build_qrc.py
@@ -18,6 +18,8 @@ def build_qrc(resources):
     yield '<qresource>'
     for d in resources:
         for root, dirs, files in os.walk(d):
+            dirs.sort()
+            files.sort()
             for f in files:
                 yield '<file>{}</file>'.format(os.path.join(root, f))
     yield '</qresource>'


### PR DESCRIPTION
so that yubioath-desktop packages build in a reproducible way
in spite of indeterministic filesystem readdir order

See https://reproducible-builds.org/ for why this is good.

Note: With the current pretty flat resource layout,
dirs has at most 1 entry so would not need to be sorted,
but OTOH sorting this will be very fast
and it avoids future problems of this kind.