### PR TITLE
bugfix: wrong mode messages was never shown

### DIFF
--- a/qml/NoLoadedDeviceMessage.qml
+++ b/qml/NoLoadedDeviceMessage.qml
@@ -19,9 +19,11 @@ Label {
         if (device.nDevices === 0) {
             return qsTr("No YubiKey detected.")
         } else if (device.nDevices === 1) {
-            if (settings.slotMode && device.enabled && !device.hasOTP) {
+            if (settings.slotMode && device.enabledUsbInterfaces
+                    && !device.hasOTP) {
                 return qsTr("Authenticator mode is set to YubiKey slots, but the OTP connection mode is not enabled.")
-            } else if (ccidMode && device.enabled && !device.hasCCID) {
+            } else if (ccidMode && device.enabledUsbInterfaces
+                       && !device.hasCCID) {
                 return qsTr("Authenticator mode is set to CCID, but the CCID connection mode is not enabled.")
             } else {
                 return qsTr("Connecting to YubiKey...")


### PR DESCRIPTION
because device.enabled variable have been renamed