### PR TITLE
Use relative font sizes where possible

### DIFF
--- a/qml/AboutPopup.qml
+++ b/qml/AboutPopup.qml
@@ -69,7 +69,6 @@ Dialog {
 
             Label {
                 text: !!yubiKey.currentDevice ? yubiKey.currentDevice.name : ""
-                font.pixelSize: 13
                 font.weight: Font.Medium
                 Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 width: parent.width
@@ -81,7 +80,6 @@ Dialog {
                 text: !!yubiKey.currentDevice ? "Serial number: " + yubiKey.currentDevice.serial : ""
                 visible: !!yubiKey.currentDevice && yubiKey.currentDevice.serial
                 color: formText
-                font.pixelSize: 13
                 Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 wrapMode: Text.WordWrap
                 Layout.maximumWidth: parent.width
@@ -93,7 +91,6 @@ Dialog {
                 text: !!yubiKey.currentDevice ? "Firmware version: " + yubiKey.currentDevice.version : ""
                 visible: !!yubiKey.currentDevice && yubiKey.currentDevice.version
                 color: formText
-                font.pixelSize: 13
                 Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 wrapMode: Text.WordWrap
                 Layout.maximumWidth: parent.width
@@ -103,7 +100,6 @@ Dialog {
             Label {
                 text: !!yubiKey.currentDevice ? qsTr("Enabled interfaces: ") + getDeviceDescription() : ""
                 color: formText
-                font.pixelSize: 13
                 Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 wrapMode: Text.WordWrap
                 Layout.maximumWidth: parent.width
@@ -138,7 +134,6 @@ Dialog {
 
         Label {
             text: qsTr("Yubico Authenticator ") + appVersion
-            font.pixelSize: 13
             font.weight: Font.Medium
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             width: parent.width
@@ -151,7 +146,6 @@ Dialog {
                            new Date(),
                            "yyyy") + ", Yubico AB.")
             color: formText
-            font.pixelSize: 13
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             wrapMode: Text.WordWrap
             Layout.maximumWidth: parent.width
@@ -161,7 +155,6 @@ Dialog {
         Label {
             text: qsTr("All rights reserved.")
             color: formText
-            font.pixelSize: 13
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             wrapMode: Text.WordWrap
             Layout.maximumWidth: parent.width

--- a/qml/ConfirmationPopup.qml
+++ b/qml/ConfirmationPopup.qml
@@ -49,7 +49,7 @@ Dialog {
         Label {
             id: confirmationHeading
             text: heading
-            font.pixelSize: 15
+            font.pixelSize: Qt.application.font.pixelSize * 1.3
             font.weight: Font.Medium
             width: parent.width
             wrapMode: Text.WordWrap
@@ -60,7 +60,6 @@ Dialog {
             id: confirmationLbl
             text: message
             color: formText
-            font.pixelSize: 13
             lineHeight: 1.2
             wrapMode: Text.WordWrap
             Layout.topMargin: 16

--- a/qml/CredentialCard.qml
+++ b/qml/CredentialCard.qml
@@ -359,7 +359,7 @@ Pane {
             spacing: 0
             Label {
                 id: codeLbl
-                font.pixelSize: 24
+                font.pixelSize: Qt.application.font.pixelSize * 1.8
                 color: Material.primary
                 text: getCodeLblValue()
             }
@@ -367,7 +367,6 @@ Pane {
                 id: nameLbl
                 text: formattedName()
                 Layout.maximumWidth: 265
-                font.pixelSize: 12
                 maximumLineCount: 3
                 wrapMode: Text.Wrap
                 color: formText

--- a/qml/CredentialCardIcon.qml
+++ b/qml/CredentialCardIcon.qml
@@ -13,7 +13,7 @@ Rectangle {
     Label {
         text: letter.toUpperCase()
         font.bold: true
-        font.pixelSize: 24
+        font.pixelSize: Qt.application.font.pixelSize * 1.8
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.verticalCenter: parent.verticalCenter
         color: yubicoWhite

--- a/qml/EnterPasswordView.qml
+++ b/qml/EnterPasswordView.qml
@@ -88,7 +88,6 @@ ScrollView {
                     Layout.rowSpan: 1
                     lineHeight: 1.2
                     wrapMode: Text.WordWrap
-                    font.pixelSize: 13
                     Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
                     color: formText
                     Layout.fillWidth: true
@@ -116,7 +115,6 @@ ScrollView {
                     CheckBox {
                         Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
                         id: rememberPasswordCheckBox
-                        font.pixelSize: 12
                         text: qsTr("Remember password")
                         leftPadding: 0
                         KeyNavigation.backtab: passwordField.textField

--- a/qml/NoCredentialsSection.qml
+++ b/qml/NoCredentialsSection.qml
@@ -27,7 +27,7 @@ ColumnLayout {
             text: qsTr("No credentials")
             Layout.rowSpan: 1
             wrapMode: Text.WordWrap
-            font.pixelSize: 16
+            font.pixelSize: Qt.application.font.pixelSize * 1.2
             font.weight: Font.Normal
             lineHeight: 1.5
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
@@ -43,7 +43,6 @@ ColumnLayout {
             Layout.rowSpan: 1
             lineHeight: 1.1
             wrapMode: Text.WordWrap
-            font.pixelSize: 13
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             color: formLabel
         }

--- a/qml/NoResultsSection.qml
+++ b/qml/NoResultsSection.qml
@@ -27,7 +27,7 @@ ColumnLayout {
             text: qsTr("No credentials found")
             Layout.rowSpan: 1
             wrapMode: Text.WordWrap
-            font.pixelSize: 16
+            font.pixelSize: Qt.application.font.pixelSize * 1.2
             font.weight: Font.Normal
             lineHeight: 1.5
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
@@ -42,7 +42,6 @@ ColumnLayout {
             Layout.rowSpan: 1
             lineHeight: 1.1
             wrapMode: Text.WordWrap
-            font.pixelSize: 13
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             color: formLabel
         }

--- a/qml/NoYubiKeySection.qml
+++ b/qml/NoYubiKeySection.qml
@@ -35,7 +35,7 @@ ColumnLayout {
                     return qsTr("Insert your YubiKey")
                 }
             }
-            font.pixelSize: 16
+            font.pixelSize: Qt.application.font.pixelSize * 1.2
             font.weight: Font.Normal
             lineHeight: 1.5
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
@@ -58,7 +58,6 @@ ColumnLayout {
             Layout.rowSpan: 1
             lineHeight: 1.1
             wrapMode: Text.WordWrap
-            font.pixelSize: 13
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             color: formLabel
         }
@@ -81,7 +80,6 @@ ColumnLayout {
                                  < dynamicWidth ? app.width - dynamicMargin : dynamicWidth
             horizontalAlignment: Qt.AlignHCenter
             wrapMode: Text.WordWrap
-            font.pixelSize: 13
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             color: formLabel
         }
@@ -98,7 +96,6 @@ ColumnLayout {
                                  < dynamicWidth ? app.width - dynamicMargin : dynamicWidth
             horizontalAlignment: Qt.AlignHCenter
             wrapMode: Text.WordWrap
-            font.pixelSize: 13
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             color: formLabel
             maximumLineCount: 1

--- a/qml/SettingsView.qml
+++ b/qml/SettingsView.qml
@@ -450,7 +450,6 @@ ScrollView {
                     visible: interfacePanel.otpModeSelected
                     Label {
                         Layout.fillWidth: true
-                        font.pixelSize: 11
                         color: formLabel
                         text: qsTr("Using the OTP slots should be considered for special cases only.")
                         wrapMode: Text.WordWrap

--- a/qml/SnackBar.qml
+++ b/qml/SnackBar.qml
@@ -48,7 +48,6 @@ ToolTip {
             text: message
             color: isDark() ? defaultDarkForeground : defaultLight
             opacity: 0.87
-            font.pixelSize: 14
             leftPadding: 8
             rightPadding: 0
             wrapMode: Text.WordWrap

--- a/qml/StyledComboBox.qml
+++ b/qml/StyledComboBox.qml
@@ -24,7 +24,6 @@ Item {
 
         Label {
             text: label
-            font.pixelSize: 10
             color: formLabel
         }
 
@@ -32,7 +31,6 @@ Item {
             id: comboBox
             Layout.fillWidth: true
             implicitWidth: container.width
-            font.pixelSize: 13
             flat: true
             Material.accent: isDark(
                                  ) ? defaultDarkForeground : defaultLightForeground
@@ -52,7 +50,6 @@ Item {
             }
             contentItem: Text {
                 color: formText
-                font.pixelSize: 13
                 text: parent.displayText
                 verticalAlignment: Text.AlignVCenter
                 horizontalAlignment: Text.AlignLeft

--- a/qml/StyledExpansionContainer.qml
+++ b/qml/StyledExpansionContainer.qml
@@ -30,7 +30,6 @@ Pane {
                 Layout.alignment: Qt.AlignLeft | Qt.AlignTop
                 text: sectionTitle
                 color: Material.primary
-                font.pixelSize: 14
                 font.weight: Font.Medium
                 topPadding: 8
                 bottomPadding: 8

--- a/qml/StyledExpansionPanel.qml
+++ b/qml/StyledExpansionPanel.qml
@@ -130,7 +130,7 @@ Pane {
                     Layout.alignment: Qt.AlignLeft | Qt.AlignTop
                     text: label
                     color: Material.primary
-                    font.pixelSize: 14
+                    font.pixelSize: Qt.application.font.pixelSize * 1.1
                     font.weight: Font.Medium
                     Layout.fillWidth: true
                 }
@@ -138,7 +138,6 @@ Pane {
                 Label {
                     visible: !isSectionTitle
                     text: label
-                    font.pixelSize: 13
                     font.bold: false
                     color: formText
                     Layout.fillWidth: true
@@ -146,7 +145,6 @@ Pane {
                 Label {
                     Layout.alignment: Qt.AlignRight | Qt.AlignTop
                     Layout.fillWidth: true
-                    font.pixelSize: 11
                     color: formLabel
                     text: description
                     wrapMode: Text.WordWrap

--- a/qml/StyledStepperPanel.qml
+++ b/qml/StyledStepperPanel.qml
@@ -108,7 +108,6 @@ Pane {
                     anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter; }
                     text: step
                     visible: !isCompleted
-                    font.pixelSize: 13
                     color: yubicoWhite
                 }
 
@@ -143,7 +142,7 @@ Pane {
                 Label {
                     Layout.alignment: Qt.AlignLeft | Qt.AlignTop
                     text: label
-                    font.pixelSize: 13
+                    wrapMode: Text.WordWrap
                     font.weight: isExpanded ? Font.Medium : Font.Normal
                     color: formText
                     Layout.fillWidth: true
@@ -151,7 +150,6 @@ Pane {
                 Label {
                     Layout.alignment: Qt.AlignLeft | Qt.AlignTop
                     Layout.fillWidth: true
-                    font.pixelSize: 11
                     color: formLabel
                     text: description
                     wrapMode: Text.WordWrap

--- a/qml/StyledTextField.qml
+++ b/qml/StyledTextField.qml
@@ -58,8 +58,7 @@ Item {
     Column {
 
         Label {
-            font.pixelSize: 10
-            height: 10
+            height: Qt.application.font.pixelSize
             color: validateInput() ? formLabel : yubicoRed
             text: labelTextValue()
         }
@@ -69,7 +68,6 @@ Item {
             Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
             selectByMouse: true
             implicitWidth: textFieldContainer.width
-            font.pixelSize: 13
             Keys.onEscapePressed: textField.focus = false
             Keys.onReturnPressed: {
                 textField.focus = false
@@ -130,7 +128,6 @@ Item {
         }
 
         Label {
-            font.pixelSize: 10
             color: yubicoRed
             text: validateText
             visible: !validateInput()

--- a/qml/StyledToolBar.qml
+++ b/qml/StyledToolBar.qml
@@ -70,7 +70,7 @@ ToolBar {
             id: titleLbl
             visible: showTitleLbl
             text: showTitleLbl ? navigator.currentItem.title : ""
-            font.pixelSize: 16
+            font.pixelSize: Qt.application.font.pixelSize * 1.2
             Layout.leftMargin: backBtn.visible ? -32 : 0
             Layout.rightMargin: shouldShowSettings() ? -80 : 0
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -12,7 +12,7 @@ ApplicationWindow {
     id: app
 
     width: 360
-    height: 620
+    height: 700
     minimumWidth: 360
     minimumHeight: 208
     visible: false


### PR DESCRIPTION
I am no QML master, but the new design was unreadable to me. I had to remove the hardcoded font size to be able to use the app again.
This is not polished, if there is interest for it, I'll look into fetching the system's font size by default and adding a configuration option in the settings.
Also, I couldn't get the search input to play nicely so its placeholder is not horizontally aligned. If someone with experience knows what's up, feel welcome to point it out.