### PR TITLE
pyotherside: fix for handling signals correct

### DIFF
--- a/py/yubikey.py
+++ b/py/yubikey.py
@@ -23,6 +23,8 @@ from ykman.oath import (
 from ykman.otp import OtpController
 from ykman.settings import Settings
 from qr import qrparse, qrdecode
+import signal
+signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
For a long time CTRL + C did not work correctly when starting the app from the terminal, resulting in behavior like this:
```
$ ./yubioath-desktop 
Got library name:  "/home/dag/Qt/5.12.4/gcc_64/qml/io/thp/pyotherside/libpyothersideplugin.so"
^C"PyOtherSide error: Traceback (most recent call last):\n\n  File \"qrc:///py/yubikey.py\", line 33, in wrapped\n    return json.dumps(f(*(json.loads(a) for a in args)))\n\n  File \"qrc:///py/yubikey.py\", line 103, in wrapped\n    return f(*args, **kwargs)\n\n  File \"qrc:///py/yubikey.py\", line 494, in get_connected_readers\n    return success({'readers': [str(reader) for reader in list_readers()]})\n\n  File \"qrc:///py/yubikey.py\", line 494, in <listcomp>\n    return success({'readers': [str(reader) for reader in list_readers()]})\n\nKeyboardInterrupt\n"
Unhandled PyOtherSide error: Return value of PyObject call is NULL: Traceback (most recent call last):

  File "qrc:///py/yubikey.py", line 33, in wrapped
    return json.dumps(f(*(json.loads(a) for a in args)))

  File "qrc:///py/yubikey.py", line 103, in wrapped
    return f(*args, **kwargs)

  File "qrc:///py/yubikey.py", line 494, in get_connected_readers
    return success({'readers': [str(reader) for reader in list_readers()]})

  File "qrc:///py/yubikey.py", line 494, in <listcomp>
    return success({'readers': [str(reader) for reader in list_readers()]})

KeyboardInterrupt

qml: TypeError: Value is undefined and could not be converted to an object undefined

```

With this fix, found here: https://github.com/thp/pyotherside/issues/33 , the signals seems to be handled correctly.
```
$ ./yubioath-desktop 
Got library name:  "/home/dag/Qt/5.12.4/gcc_64/qml/io/thp/pyotherside/libpyothersideplugin.so"
^C
$ echo $?
130
```