### PR TITLE
Add various Windows specific qmake metadata for better display

### DIFF
--- a/yubioath-desktop.pro
+++ b/yubioath-desktop.pro
@@ -7,6 +7,10 @@ HEADERS += screenshot.h
 # This is the internal verson number, Windows requires 4 digits.
 win32|win64 {
     VERSION = 5.0.1.0
+    QMAKE_TARGET_COMPANY = Yubico
+    QMAKE_TARGET_PRODUCT = Yubico Authenticator
+    QMAKE_TARGET_DESCRIPTION = Yubico Authenticator
+    QMAKE_TARGET_COPYRIGHT = Copyright (c) 2017 Yubico AB
 } else {
     VERSION = 5.0.1
 }


### PR DESCRIPTION
Prior to this PR, notifications in Windows used the default executable name ("yubioath-desktop.exe"), which looked slightly ugly:

![Windows notification](https://user-images.githubusercontent.com/1723612/69832555-f368a480-1226-11ea-8661-ea9afacf77c4.png)

This adds the `QMAKE_TARGET_{COMPANY,PRODUCT,DESCRIPTION,COPYRIGHT}` variables to the Windows qmake build (they're [exclusive to Windows](https://doc.qt.io/qt-5/qmake-variable-reference.html#qmake-target-company))