### PR TITLE
Allow spaces in manual secret key input field

### DIFF
--- a/qml/NewCredentialView.qml
+++ b/qml/NewCredentialView.qml
@@ -30,11 +30,13 @@ Flickable {
     contentHeight: content.implicitHeight + dynamicMargin
 
     function acceptableInput() {
+        // trim spaces to accurately count length, parse_b32_key later trims them
+        var secretKeyTrimmed = secretKeyLbl.text.replace(/ /g, "")
         if (settings.otpMode) {
-            return secretKeyLbl.text.length > 0 && secretKeyLbl.text.length <= 32
+            return secretKeyTrimmed.length > 0 && secretKeyTrimmed.length <= 32
         } else {
             var nameAndKey = nameLbl.text.length > 0
-                    && secretKeyLbl.text.length > 0
+                    && secretKeyTrimmed.length > 0
             var okTotalLength = (nameLbl.text.length + issuerLbl.text.length) < 60
             return nameAndKey && okTotalLength
         }
@@ -250,7 +252,7 @@ Flickable {
                                       && credential.secret ? credential.secret : ""
                                 visible: manualEntry
                                 validateText: qsTr("Invalid Base32 format (A-Z and 2-7)")
-                                validateRegExp: /^[2-7a-zA-Z]+=*$/
+                                validateRegExp: /^[2-7a-zA-Z ]+[= ]*$/
                                 Layout.bottomMargin: 12
                                 onSubmit: addCredential()
                             }


### PR DESCRIPTION
Many sites put spaces in their secret keys for readability, and since we later strip spaces: 

https://github.com/Yubico/yubioath-desktop/blob/24ae87a286bc564a6f1afdfc5a696fa65a893c5c/py/yubikey.py#L339 

https://github.com/Yubico/yubikey-manager/blob/1f22620b623c6b345dd9f9193ec765a542dddc80/ykman/util.py#L458

...just accept them anyway.