### PR TITLE
Use keys.openpgp.org to fetch GPG keys

### DIFF
--- a/.github/workflows/windows-x64.yml
+++ b/.github/workflows/windows-x64.yml
@@ -21,7 +21,7 @@ jobs:
         shell: powershell
 
       - name: Fetch GPG keys
-        run: gpg --no-default-keyring --keyring yubico --recv-keys 0A3B0262BCA1705307D5FF06BCA00FD4B2168C0A
+        run: gpg --no-default-keyring --keyring yubico --keyserver hkps://keys.openpgp.org --recv-keys 0A3B0262BCA1705307D5FF06BCA00FD4B2168C0A
 
       - name: Verify signature/checksums of downloaded files
         run: |

--- a/.github/workflows/windows-x86.yml
+++ b/.github/workflows/windows-x86.yml
@@ -21,7 +21,7 @@ jobs:
         shell: powershell
 
       - name: Fetch GPG keys
-        run: gpg --no-default-keyring --keyring yubico --recv-keys 0A3B0262BCA1705307D5FF06BCA00FD4B2168C0A
+        run: gpg --no-default-keyring --keyring yubico --keyserver hkps://keys.openpgp.org --recv-keys 0A3B0262BCA1705307D5FF06BCA00FD4B2168C0A
 
       - name: Verify signature/checksums of downloaded files
         run: |


### PR DESCRIPTION
Should fix stability issues in Windows build workflow.