### PR TITLE
Explicitly use python3 while building

### DIFF
--- a/yubioath-desktop.pro
+++ b/yubioath-desktop.pro
@@ -19,7 +19,7 @@ DEFINES += APP_VERSION=\\\"5.0.1\\\"
 
 message(Version of this build: $$VERSION)
 
-buildqrc.commands = python build_qrc.py ${QMAKE_FILE_IN}
+buildqrc.commands = python3 build_qrc.py ${QMAKE_FILE_IN}
 buildqrc.input = QRC_JSON
 buildqrc.output = ${QMAKE_FILE_IN_BASE}.qrc
 buildqrc.variable_out = RESOURCES
@@ -30,7 +30,7 @@ QMAKE_EXTRA_COMPILERS += buildqrc
 QRC_JSON = resources.json
 
 # Generate first time
-system(python build_qrc.py resources.json)
+system(python3 build_qrc.py resources.json)
 
 # Install python dependencies with pip on mac and win
 win32|macx {


### PR DESCRIPTION
Hello,

This pull request allows me to avoid the following patch:

```
Description: updated upstream qmake file to use python 3
Author: Taowa Munene-Tardif <taowa@debian.org>
Last-Update: 2019-12-21 
---
This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
Index: taowa/yubioath-desktop.pro
===================================================================
--- taowa.orig/yubioath-desktop.pro	2019-12-21 21:16:19.679250303 -0500
+++ taowa/yubioath-desktop.pro	2019-12-21 21:18:21.762839757 -0500
@@ -15,7 +15,7 @@
 
 message(Version of this build: $$VERSION)
 
-buildqrc.commands = python build_qrc.py ${QMAKE_FILE_IN}
+buildqrc.commands = python3 build_qrc.py ${QMAKE_FILE_IN}
 buildqrc.input = QRC_JSON
 buildqrc.output = ${QMAKE_FILE_IN_BASE}.qrc
 buildqrc.variable_out = RESOURCES
@@ -26,7 +26,7 @@
 QRC_JSON = resources.json
 
 # Generate first time
-system(python build_qrc.py resources.json)
+system(python3 build_qrc.py resources.json)
 
 # Install python dependencies with pip on mac and win
 win32|macx {
```

Else the build fails on Debian without python2.

Thanks,
Taowa
