### PR TITLE
Use AppData in Linux builds

### DIFF
--- a/debian/yubioath-desktop.install
+++ b/debian/yubioath-desktop.install
@@ -1,2 +1,3 @@
 resources/com.yubico.yubioath.desktop usr/share/applications
+resources/com.yubico.yubioath.appdata.xml usr/share/metainfo
 resources/icons/com.yubico.yubioath.svg usr/share/pixmaps

--- a/docker/xenial-appimage/Dockerfile
+++ b/docker/xenial-appimage/Dockerfile
@@ -46,6 +46,7 @@ RUN mkdir -p yubioath-desktop/appDir/usr \
     && qmake \
     && make \
     && cp resources/com.yubico.yubioath.desktop appDir/ \
+    && cp resources/com.yubico.yubioath.appdata.xml appDir/ \
     && cp resources/icons/com.yubico.yubioath.svg appDir/ \
     && cp ./yubioath-desktop appDir/usr/bin/ \
     && wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" \


### PR DESCRIPTION
In #524 we added `appdata.xml` file to the repository. In this PR we are using it during install scripts for Linux.

* I added AppData to Debian script according to [Debian guideline](https://wiki.debian.org/AppStream/Guidelines#General)
* I didn’t check AppImageKit, but according to [it’s sources](https://github.com/AppImage/AppImageKit/blob/23267a1ed9276c4bdfb4d3a6137733a936f09490/src/appimagetool.c#L779) AppImageKit should load AppData from `appDir/`

@dagheyman We will need a release after merging this PR to start working for Flatpak.