### PR TITLE
actions: build snap package

### DIFF
--- a/.github/workflows/snap-pyscard-patch.patch
+++ b/.github/workflows/snap-pyscard-patch.patch
@@ -1,0 +1,22 @@
+From 6dd501199c1323a49f2e64e75c886a1d0b652577 Mon Sep 17 00:00:00 2001
+From: Dag Heyman <dag@yubico.com>
+Date: Thu, 20 Feb 2020 18:05:59 +0100
+Subject: [PATCH] setup.py: add typical snapcraft location of PCSC
+
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 939e60f..ba54c7c 100755
+--- a/setup.py
++++ b/setup.py
+@@ -76,7 +76,7 @@
+     platform_swig_opts = ['-DPCSCLITE']
+     platform_sources = []
+     platform_libraries = []
+-    platform_include_dirs = ['/usr/include/PCSC', '/usr/local/include/PCSC']
++    platform_include_dirs = ['/root/stage/usr/include/PCSC']
+     platform_extra_compile_args = []    # ['-ggdb', '-O0']
+     platform_extra_link_args = []   # ['-ggdb']
+ 

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,0 +1,34 @@
+name: Build snap package
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Build snap
+        run: |
+          sudo snap install snapcraft --classic
+          sudo chown root:root /
+          sudo apt-get remove -qy lxd lxd-client
+          sudo snap install lxd
+          sudo lxd init --auto
+          export REF=$(echo ${GITHUB_REF} | cut -d '/' -f 3)
+          sudo snapcraft --use-lxd
+          mkdir deploy
+          mv yubioath-desktop*.snap yubioath-desktop-${REF}.snap
+          cp yubioath-desktop*.snap deploy
+
+      - name: Install snap
+        run: |
+          sudo snap install yubioath-desktop*.snap --devmode
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: yubioath-desktop-snap
+          path: deploy

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,9 +42,6 @@ apps:
       - u2f-devices
       - hidraw
       - hardware-observe
-      - network
-      - network-bind
-      - network-observe
       - ykman-config
     extensions: [gnome-3-28]
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -110,7 +110,12 @@ parts:
     override-build: |
       eval "$(pyenv init -)"
       pyenv global 3.8.1
-      pip3 install git+git://github.com/dagheyman/pyscard.git#egg=pyscard
+      pip3 download --no-binary :all: pyscard
+      tar -xvf pyscard*
+      cd pyscard*
+      patch setup.py ../.github/workflows/snap-pyscard-patch.patch
+      pip3 install .
+      cd ..
       pip3 install -r requirements.txt
     override-stage: |
       snapcraftctl stage

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,226 @@
+name: yubioath-desktop
+adopt-info: yubioath-desktop
+icon: resources/icons/com.yubico.yubioath.svg
+base: core18
+grade: devel
+confinement: strict
+
+plugs:
+  ykman-config:
+    interface: personal-files
+    write:
+      - $HOME/.ykman
+apps:
+  pcscd:
+    command: usr/sbin/pcscd --foreground --auto-exit
+    daemon: simple
+    common-id: com.yubico.pcscd
+    plugs:
+      - hardware-observe
+      - network
+      - network-bind
+      - raw-usb
+
+  yubioath-desktop:
+    adapter: full
+    command: yubioath-desktop
+    common-id: com.yubico.yubioath
+    environment:
+      LD_LIBRARY_PATH: $SNAP/opt/qt514/lib/x86_64-linux-gnu/:$SNAP/opt/qt514/lib/:$LD_LIBRARY_PATH:$SNAP/usr/lib/
+      QT_QPA_PLATFORM: xcb
+      QT_BASE_DIR: $SNAP/opt/qt514/
+      QT_PLUGIN_PATH: $SNAP/opt/qt514/plugins/
+      QML2_IMPORT_PATH: $SNAP/opt/qt514/qml/
+    plugs:
+      - desktop
+      - desktop-legacy
+      - wayland
+      - unity7
+      - opengl
+      - x11
+      - raw-usb
+      - u2f-devices
+      - hidraw
+      - hardware-observe
+      - network
+      - network-bind
+      - network-observe
+      - ykman-config
+    extensions: [gnome-3-28]
+
+parts:
+
+  ppa-qt:
+    plugin: nil
+    build-packages:
+      - software-properties-common
+    override-pull: |
+      add-apt-repository -y ppa:beineri/opt-qt-5.14.1-bionic
+      apt-get -qq update
+      apt-get install -y qt514-meta-full
+
+  ppa-ykpers:
+    plugin: nil
+    build-packages:
+      - software-properties-common
+    override-pull: |
+      add-apt-repository -y ppa:yubico/stable
+      apt-get -qq update
+      apt-get install -y libykpers-1-1
+
+
+  python:
+    plugin: nil
+    build-packages:
+      - git
+      - zlib1g-dev
+      - libbz2-dev
+      - libssl-dev
+      - libffi-dev
+      - libreadline-dev
+      - libsqlite3-dev
+    build-environment:
+      - PATH: /root/.pyenv/bin:$PATH
+      - PYTHON_CFLAGS: -fPIC
+      - PYTHON_CONFIGURE_OPTS: --enable-shared
+    override-pull: |
+      rm -rf /root/.pyenv
+      curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+    override-build: |
+      eval "$(pyenv init -)"
+      pyenv update
+      pyenv install --force 3.8.1
+      pyenv global 3.8.1
+      pip3 install --upgrade pip
+    override-stage: |
+      snapcraftctl stage
+      rsync -a /root/.pyenv/versions/3.8.1/* /root/stage/usr/
+    override-prime: |
+      snapcraftctl prime
+      rsync -a /root/.pyenv/versions/3.8.1/* /root/prime/usr/
+
+  python-deps:
+    plugin: dump
+    source: .
+    after: [python]
+    build-packages:
+      - swig
+    build-environment:
+      - PATH: /root/.pyenv/bin:$PATH
+    override-build: |
+      eval "$(pyenv init -)"
+      pyenv global 3.8.1
+      pip3 install git+git://github.com/dagheyman/pyscard.git#egg=pyscard
+      pip3 install -r requirements.txt
+    override-stage: |
+      snapcraftctl stage
+      rsync -a /root/.pyenv/versions/3.8.1/* /root/stage/usr/
+    override-prime: |
+      snapcraftctl prime
+      rsync -a /root/.pyenv/versions/3.8.1/* /root/prime/usr/
+
+  pyotherside:
+    plugin: qmake
+    after: [python, ppa-qt]
+    source-type: tar
+    source: https://github.com/thp/pyotherside/archive/1.5.9.tar.gz
+    override-pull: |
+      snapcraftctl pull
+      echo "DEFINES += QT_NO_DEBUG_OUTPUT" >> src/src.pro
+    build-environment:
+      - QT_BASE_DIR: /opt/qt514
+      - QT_DIR: /opt/qt514
+      - QT_BASE_DIR: /opt/qt514
+      - LD_LIBRARY_PATH: $QT_BASE_DIR/lib/x86_64-linux-gnu:$QT_BASE_DIR/lib:$LD_LIBRARY_PATH
+      - PKG_CONFIG_PATH: $QT_BASE_DIR/lib/pkgconfig:$PKG_CONFIG_PATH
+      - PATH: /root/.pyenv/bin:$QT_BASE_DIR/bin:$PATH
+      - INSTALL_ROOT: $SNAPCRAFT_PART_INSTALL
+    override-build: |
+      eval "$(pyenv init -)"
+      pyenv global 3.8.1
+      snapcraftctl build
+
+  pcsc-lite:
+    plugin: autotools
+    source-type: tar
+    source: https://pcsclite.apdu.fr/files/pcsc-lite-1.8.25.tar.bz2
+    configflags:
+      - --enable-ipcdir=/run/snap.yubioath-desktop
+      - --enable-runpid=/run/snap.yubioath-desktop/pcscd/pcscd.pid
+      - --enable-confdir=/snap/yubioath-desktop/current/etc/reader.conf.d
+      - --enable-usbdropdir=/snap/yubioath-desktop/current/usr/lib/pcsc/drivers
+      - --prefix=/snap/yubioath-desktop/current/usr
+    build-packages:
+      - gcc
+      - pkg-config
+      - libsystemd-dev
+      - libudev-dev
+    override-build: |
+      snapcraftctl build
+      cp -r ${SNAPCRAFT_PART_INSTALL}/snap/yubioath-desktop/current/usr ${SNAPCRAFT_PART_INSTALL}/
+      rm -r ${SNAPCRAFT_PART_INSTALL}/snap ${SNAPCRAFT_PART_INSTALL}/lib
+      sed -i -e 's/\/snap\/yubioath-desktop\/current//g' ${SNAPCRAFT_PART_INSTALL}/usr/lib/pkgconfig/libpcsclite.pc
+
+  ccid:
+    plugin: autotools
+    source-type: tar
+    configflags:
+      - --enable-usbdropdir=/snap/yubioath-desktop/current/usr/lib/pcsc/drivers
+      - --prefix=/usr
+    source: https://ccid.apdu.fr/files/ccid-1.4.31.tar.bz2
+    build-packages:
+      - pkg-config
+      - libusb-1.0-0-dev
+    override-build: |
+      snapcraftctl build
+      cp -r ${SNAPCRAFT_PART_INSTALL}/snap/yubioath-desktop/current/usr ${SNAPCRAFT_PART_INSTALL}/
+      rm -r ${SNAPCRAFT_PART_INSTALL}/snap
+    stage-packages:
+      - libusb-1.0-0
+    after: [pcsc-lite]
+
+  yubioath-desktop:
+    source: .
+    plugin: qmake
+    after: [pyotherside]
+    parse-info: [resources/com.yubico.yubioath.appdata.xml]
+    stage-packages:
+      - libfreetype6
+      - libgl1
+      - libglvnd0
+      - libglx0
+      - libgraphite2-3
+      - libharfbuzz0b
+      - libicu60
+      - libpng16-16
+      - libx11-6
+      - libxau6
+      - libxcb1
+      - libglu1-mesa
+      - libxdmcp6
+      - qt514base
+      - qt514declarative
+      - qt514quickcontrols
+      - qt514quickcontrols2
+      - qt514svg
+      - qt514graphicaleffects
+      - libxkbcommon0
+      - ttf-ubuntu-font-family
+      - dmz-cursor-theme
+      - light-themes
+      - adwaita-icon-theme
+      - gnome-themes-standard
+      - shared-mime-info
+      - libgdk-pixbuf2.0-0
+      - locales-all
+      - xdg-user-dirs
+      - libykpers-1-1
+      - libgtk2.0-0
+      - libusb-1.0-0
+    build-environment:
+      - QT_BASE_DIR: /opt/qt514
+      - QT_DIR: /opt/qt514
+      - LD_LIBRARY_PATH: $QT_BASE_DIR/lib/x86_64-linux-gnu:$QT_BASE_DIR/lib:$LD_LIBRARY_PATH
+      - PKG_CONFIG_PATH: $QT_BASE_DIR/lib/pkgconfig:$PKG_CONFIG_PATH
+      - PATH: /root/.pyenv/bin:$QT_BASE_DIR/bin:$PATH
+      - INSTALL_ROOT: $SNAPCRAFT_PART_INSTALL


### PR DESCRIPTION
Add initial snap build, based on qt 5.14 and custom python. I think this is ready for initial merging, even if there is some stuff left to do.

Testing:
```
$ sudo snap install yubioath-desktop_5.0.2_amd64.snap --dangerous
$ sudo snap connect yubioath-desktop:hardware-observe :hardware-observe
$ sudo snap connect yubioath-desktop:raw-usb :raw-usb
$ sudo snap connect yubioath-desktop:u2f-devices :u2f-devices
$ sudo snap connect yubioath-desktop:ykman-config :personal-files
$ sudo snap restart yubioath-desktop.pcscd
```

TODO:
- the bundled pcscd is now just installed and started, probably needs to be handled better. See https://forum.snapcraft.io/t/best-way-to-talk-to-smart-cards-pcscd/15318/
- all the manual connections above will hopefully go away after requesting auto connections. See https://snapcraft.io/docs/permission-requests