### PR TITLE
snap: store .ykman settings in SNAP_USER_DATA

### DIFF
--- a/.github/workflows/snap-ykman-settings.patch
+++ b/.github/workflows/snap-ykman-settings.patch
@@ -1,0 +1,25 @@
+From 373b80b420c04f897fccd10288f994bb66825011 Mon Sep 17 00:00:00 2001
+From: Dag Heyman <dag@yubico.com>
+Date: Tue, 3 Mar 2020 08:29:16 +0100
+Subject: [PATCH] ykman: use SNAP directory for settings
+
+---
+ ykman/settings.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ykman/settings.py b/ykman/settings.py
+index ef76670..5b7b942 100644
+--- a/ykman/settings.py
++++ b/ykman/settings.py
+@@ -42,7 +42,7 @@ def _get_conf_dir():
+ 
+ class Settings(dict):
+     def __init__(self, name):
+-        self.fname = os.path.join(_get_conf_dir(), name + '.json')
++        self.fname = os.path.join(os.getenv('SNAP_USER_DATA'), '.config', '.ykman', name + '.json')
+         if os.path.isfile(self.fname):
+             with open(self.fname, 'r') as f:
+                 self.update(json.load(f))
+-- 
+2.20.1
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,11 +5,6 @@ base: core18
 grade: devel
 confinement: strict
 
-plugs:
-  ykman-config:
-    interface: personal-files
-    write:
-      - $HOME/.ykman
 apps:
   pcscd:
     command: usr/sbin/pcscd --foreground --auto-exit
@@ -42,7 +37,6 @@ apps:
       - u2f-devices
       - hidraw
       - hardware-observe
-      - ykman-config
     extensions: [gnome-3-28]
 
 parts:
@@ -111,6 +105,12 @@ parts:
       tar -xvf pyscard*
       cd pyscard*
       patch setup.py ../.github/workflows/snap-pyscard-patch.patch
+      pip3 install .
+      cd ..
+      pip3 download --no-binary :all: yubikey-manager
+      tar -xvf yubikey-manager*
+      cd yubikey-manager*
+      patch ykman/settings.py ../.github/workflows/snap-ykman-settings.patch
       pip3 install .
       cd ..
       pip3 install -r requirements.txt


### PR DESCRIPTION
This allows us to get rid of the [`personal-files` ](https://snapcraft.io/docs/personal-files-interface) interface, which requires manual review from Snapcraft. It also makes the saved passwords only apply to the snapped version of the app, which I think makes sense.