### PR TITLE
mac: add entitlement for unsigned executable memory

### DIFF
--- a/resources/mac/entitlements.plist
+++ b/resources/mac/entitlements.plist
@@ -4,6 +4,8 @@
 <dict>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
     <key>com.apple.security.app-sandbox</key>
     <true/>
     <key>com.apple.security.device.usb</key>


### PR DESCRIPTION
This fixes a bug in Python ctypes, causing a MemoryError when run inside codesigned app bundle.

The app would fail with 
```
File "/Users/catalina/Downloads/Yubico Authenticator.app/Contents/Frameworks/Python.framework/Versions/3.7/lib/python3.7/ctypes/_init_.py", line 551, in <module>
    _reset_cache() 
File "/Users/catalina/Downloads/Yubico Authenticator.app/Contents/Frameworks/Python.framework/Versions/3.7/lib/python3.7/ctypes/_init_.py", line 273, in _reset_cache
    CFUNCTYPE(c_int)(lambda: None)
MemoryError
```


See https://code.activestate.com/lists/pythonmac-sig/24590/ and https://fman.io/blog/fman-works-again-on-macos-mojave/