### PR TITLE
improve ccid error handling

### DIFF
--- a/py/yubikey.py
+++ b/py/yubikey.py
@@ -6,6 +6,7 @@ import logging
 import types
 import time
 import ykman.logging_setup
+import smartcard.pcsc.PCSCExceptions
 from base64 import b32encode, b64decode
 from binascii import a2b_hex, b2a_hex
 from ykman.descriptor import (
@@ -117,6 +118,8 @@ def catch_error(f):
             raise
         except CCIDError:
             return failure('ccid_error')
+        except smartcard.pcsc.PCSCExceptions.EstablishContextException:
+            return failure('no_pcscd')
         except Exception as e:
             if str(e) == 'Incorrect padding':
                 return failure('incorrect_padding')

--- a/qml/Navigator.qml
+++ b/qml/Navigator.qml
@@ -126,6 +126,8 @@ StackView {
             return qsTr('Failed to read from slots')
         case 'failed_to_parse_uri':
             return qsTr('Failed to read credential from QR code')
+        case 'no_pcscd':
+            return qsTr('Is the pcscd/smart card service running?')
         default:
             return qsTr('Unknown error')
         }

--- a/qml/YubiKey.qml
+++ b/qml/YubiKey.qml
@@ -239,7 +239,7 @@ Python {
                 if (!currentDevice || !availableDevices.some(dev => dev.serial === currentDevice.serial)) {
                     // new device is being loaded, clear any old device
                     clearCurrentDeviceAndEntries()
-
+                    navigator.goToLoading()
                     if (availableDevices.some(dev => dev.selectable)) {
                         // pick the first selectable device
                         currentDevice = resp.devices.find(dev => dev.selectable)
@@ -309,6 +309,11 @@ Python {
                     currentDevice.hasPassword = true
                     currentDeviceValidated = false
                     navigator.goToEnterPasswordIfNotInSettings()
+                } else if (resp.error_id === 'open_device_failed') {
+                    clearCurrentDeviceAndEntries()
+                    yubiKey.availableDevices = []
+                    navigator.snackBarError(navigator.getErrorMessage(resp.error_id))
+                    navigator.goToCredentialsIfNotInSettings()
                 } else {
                     clearCurrentDeviceAndEntries()
                     console.log("calculateAll failed:", resp.error_id)


### PR DESCRIPTION
this change is meant to handle a couple of scenarios:

- No pcscd or smart card services is running at all. Catch `EstablishContextException` from pyscard if we want to handle it better later, requires some refactoring though. Currently this results in a generic error shown to the user, but the debug log should tell what is going on.

- Pcscd is running, but can't grab the device (LIBUSB_ERROR_BUSY) or list readers. This can happen in the snap version, since a competing pcscd might have grabbed it. Same behavior, just show an error to the user.