### PR TITLE
Fix wrong versions order in AppData#releases

### DIFF
--- a/resources/com.yubico.yubioath.appdata.xml
+++ b/resources/com.yubico.yubioath.appdata.xml
@@ -38,8 +38,6 @@
       </release>
       <release version="5.0.3-beta2" type="development" date="2020-03-27">
       </release>
-      <release version="5.0.3" type="development" date="2020-02-24">
-      </release>
       <release version="5.0.2" date="2020-01-29">
       <description>
         <ul>


### PR DESCRIPTION
Right now Flatpak builder [falls](https://flathub.org/builds/#/builders/28/builds/2162) because:

```
com.yubico.yubioath:               AppData problem: tag-invalid : <release> version was duplicated
com.yubico.yubioath:               AppData problem: tag-invalid : <release> versions are not in order [5.0.3 before 5.0.3-beta2]
```

Seems like `<release version="5.0.3" type="development"` is invalid. Development version should have some postfix like `-alpha`.

/cc @dagheyman