### PR TITLE
drop auto search when typing

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -355,6 +355,5 @@ ApplicationWindow {
         id: navigator
         anchors.fill: parent
         focus: true
-        Keys.forwardTo: toolBar.searchField
     }
 }


### PR DESCRIPTION
Require the user to enable search field by using the mouse or Ctrl/Cmd + F before searching, will also prevent accidental Yubico OTPs to enable the search. Relates to #549 