### PR TITLE
credview: quick fix for password glitch

### DIFF
--- a/qml/CredentialsView.qml
+++ b/qml/CredentialsView.qml
@@ -38,7 +38,7 @@ Pane {
 
     NoCredentialsSection {
         id: noCredentialsSection
-        visible: entries.count === 0 && (!!yubiKey.currentDevice)
+        visible: entries.count === 0 && (!!yubiKey.currentDevice) && yubiKey.currentDeviceValidated
         enabled: visible
         Accessible.ignored: true
     }

--- a/qml/YubiKey.qml
+++ b/qml/YubiKey.qml
@@ -252,7 +252,8 @@ Python {
                     // If oath is enabled, do a calculate all
                     if (currentDeviceOathEnabled) {
                         calculateAll(navigator.goToCredentialsIfNotInSettings)
-                    } else {                 
+                    } else {
+                        currentDeviceValidated = true
                         navigator.goToCredentialsIfNotInSettings()
                     }
                 } else {


### PR DESCRIPTION
Sets currentDeviceValidated  to true for all devices that does not have OATH enabled, need to clean this up a bit later to make it more clear what it means.