### PR TITLE
Fixed snap not starting under Wayland

### DIFF
--- a/docker/xenial-appimage/Dockerfile
+++ b/docker/xenial-appimage/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update -qq \
     && add-apt-repository -y ppa:beineri/opt-qt-5.14.2-xenial \
     && apt-get -qq update \
     && apt-get -qq upgrade
-RUN apt-get install -y git make build-essential libssl-dev zlib1g-dev libbz2-dev \
+RUN apt-get install -y git make build-essential g++ libssl-dev zlib1g-dev libbz2-dev \
     devscripts equivs python3-dev python3-pip python3-venv wget fuse \
     qt514base qt514declarative qt514xmlpatterns qt514script qt514tools qt514multimedia \
     qt514svg qt514graphicaleffects qt514imageformats qt514translations qt514quickcontrols \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -104,7 +104,7 @@ parts:
       eval "$(pyenv init -)"
       pyenv global 3.8.2
       pip3 download --no-binary :all: pyscard
-      tar -xvf pyscard*
+      tar -xvf pyscard*.tar*
       cd pyscard*
       patch setup.py ../.github/workflows/snap-pyscard-patch.patch
       pip3 install .

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -208,6 +208,7 @@ parts:
       - qt514quickcontrols2
       - qt514svg
       - qt514graphicaleffects
+      - qtwayland5
       - libxkbcommon0
       - ttf-ubuntu-font-family
       - dmz-cursor-theme

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,6 +26,7 @@ apps:
       QT_BASE_DIR: $SNAP/opt/qt514/
       QT_PLUGIN_PATH: $SNAP/opt/qt514/plugins/
       QML2_IMPORT_PATH: $SNAP/opt/qt514/qml/
+      DISABLE_WAYLAND: 1
     plugs:
       - desktop
       - desktop-legacy


### PR DESCRIPTION
This patch allows the snap to be run under Wayland.

In addition, I fixed some errors I encountered during the build process.