### PR TITLE
Set focus on search field when app is made visible, adds option to minimize window on code copy.

### DIFF
--- a/qml/CredentialCard.qml
+++ b/qml/CredentialCard.qml
@@ -73,6 +73,10 @@ Pane {
     function copyCode(code) {
         clipBoard.push(code)
         navigator.snackBar(qsTr("Code copied to clipboard"))
+
+        if (settings.minimizeOnCopy) {
+            app.hide()
+        }
     }
 
     function calculateCard(copy) {

--- a/qml/SettingsView.qml
+++ b/qml/SettingsView.qml
@@ -566,6 +566,17 @@ Flickable {
                         indicator.height: 16
                         onCheckStateChanged: settings.hideOnLaunch = checked
                     }
+
+                    CheckBox {
+                        id: minimizeOnCopyCheckbox
+                        enabled: true
+                        checked: settings.minimizeOnCopy
+                        text: qsTr("Minimize on copy")
+                        padding: 0
+                        indicator.width: 16
+                        indicator.height: 16
+                        onCheckStateChanged: settings.minimizeOnCopy = checked
+                    }
                 }
             }
 

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -69,6 +69,10 @@ ApplicationWindow {
     property bool isInForeground: visibility != 3 && visibility != 0
     onIsInForegroundChanged: {
         (poller.running = isInForeground || settings.closeToTray)
+
+        if (isInForeground && header.showSearch) {
+            header.searchField.forceActiveFocus()
+        }
     }
     Component.onCompleted: {
         updateTrayVisibility()
@@ -300,6 +304,7 @@ ApplicationWindow {
         property bool closeToTray
         property bool hideOnLaunch
         property bool requireTouch: true
+        property bool minimizeOnCopy
 
         property int theme: Material.System
 


### PR DESCRIPTION
This PR adds a couple of improvements for quicker use. With these modifications you are able to open the app from the tray icon, instantly seach for the code you want, copy it to clipboard and enable the app to automatically hide again.

- Sets the default focus to search field when the app enters the foreground.
- Adds an option to minimize the window automatically after copying TOTP code.
