### PR TITLE
Don't show the Authenticator view if OATH isn't available

### DIFF
--- a/qml/Navigator.qml
+++ b/qml/Navigator.qml
@@ -8,6 +8,7 @@ StackView {
 
     initialItem: authenticatorView
 
+
     onCurrentItemChanged: {
         if (currentItem) {
             currentItem.forceActiveFocus()
@@ -77,6 +78,7 @@ StackView {
     }
 
     function goToAuthenticator() {
+        settings.activeView = 'authenticatorView'
 
         // Before navigating to Authenticator view,
         // Make sure credentials are up to date by doing
@@ -108,6 +110,7 @@ StackView {
     }
 
     function goToYubiKey() {
+        settings.activeView = 'yubiKeyView'
         if (currentItem.objectName !== 'yubiKeyView') {
             clearAndPush(yubiKeyView, StackView.Immediate)
         }

--- a/qml/YubiKey.qml
+++ b/qml/YubiKey.qml
@@ -293,9 +293,15 @@ Python {
                     clearCurrentDeviceAndEntries()
                     // Just pick the first device
                     currentDevice = availableDevices[0]
-                    // If oath is enabled, do a calculate all
-                    if (yubiKey.currentDeviceEnabled("OATH") && navigator.isInAuthenticator()) {
-                        oathCalculateAllOuter()
+                    if(!!currentDevice) {
+                        if (yubiKey.currentDeviceEnabled("OATH")) {
+                            // If oath is enabled, do a calculate all
+                            if (navigator.isInAuthenticator()) {
+                                oathCalculateAllOuter()
+                            }
+                        } else if (navigator.isInAuthenticator()) {
+                            navigator.goToYubiKey()
+                        }
                     }
                 } else {
                     // the same one but potentially updated
@@ -330,12 +336,18 @@ Python {
                     clearCurrentDeviceAndEntries()
                     // Just pick the first device
                     currentDevice = availableDevices[0]
-                    // If oath is enabled, do a calculate all and go to authenticator
-                    if (yubiKey.currentDeviceEnabled("OATH") && navigator.isInAuthenticator()) {
-                        navigator.goToLoading()
-                        navigator.goToAuthenticator()
-                    }
 
+                    if(!!currentDevice) {
+                        if (yubiKey.currentDeviceEnabled("OATH")) {
+                            // If oath is enabled, do a calculate all and go to authenticator
+                            if (navigator.isInAuthenticator()) {
+                                navigator.goToLoading()
+                                navigator.goToAuthenticator()
+                            }
+                        } else if (navigator.isInAuthenticator()) {
+                            navigator.goToYubiKey()
+                        }
+                    }
                 } else {
                     // the same one but potentially updated
                     currentDevice = resp.devices.find(dev => dev.serial === currentDevice.serial)

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -88,6 +88,7 @@ ApplicationWindow {
         updateTrayVisibility()
         ensureMinimumWindowSize()
         ensureValidWindowPosition()
+        restoreLastView()
         app.visible = !(settings.closeToTray && settings.hideOnLaunch)
     }
 
@@ -132,6 +133,13 @@ ApplicationWindow {
 
     function isDark() {
         return app.Material.theme === Material.Dark
+    }
+
+    function restoreLastView() {
+        if(settings.activeView == 'yubiKeyView') {
+            navigator.goToYubiKey()
+        }
+        // Defaults to "authenticatorView"
     }
 
     function saveScreenLayout() {
@@ -381,6 +389,8 @@ ApplicationWindow {
         property int desktopAvailableHeight
 
         property var favorites: []
+
+        property string activeView
 
         onCloseToTrayChanged: updateTrayVisibility()
         onThemeChanged: {

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -252,6 +252,7 @@ ApplicationWindow {
         sequence: "Ctrl+1"
         onActivated: navigator.goToAuthenticator()
         context: Qt.ApplicationShortcut
+        enabled: yubiKey.currentDeviceEnabled("OATH")
     }
 
     Shortcut {


### PR DESCRIPTION
Switches to the YubiKey view when the current device changes, and the device doesn't have OATH enabled.