### PR TITLE
snap: ensure the pcscd daemon is up

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,8 +7,10 @@ confinement: strict
 
 apps:
   pcscd:
-    command: usr/sbin/pcscd --foreground --auto-exit
+    command: usr/sbin/pcscd --foreground
     daemon: simple
+    restart-condition: always
+    restart-delay: 1s
     common-id: com.yubico.pcscd
     plugs:
       - hardware-observe


### PR DESCRIPTION
snap: ensure the pcscd daemon is up

After some inactivity, the pcscd daemon will gracefully shutdown, preventing
yubioath to detect the key. Users are instructed to restart pcscd by hand when
that happens.

Fix it: ensure the daemon does not shutdown, and is restarted when that
happen.

Resolves: https://github.com/Yubico/yubioath-desktop/issues/656
