### PR TITLE
Don't analyze intermediate manifests, only the merged one.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -36,5 +36,6 @@ analyzer:
   exclude:
     - "**/*.g.dart"
     - "**/*.freezed.dart"
+    - "build/**/intermediates/**/AndroidManifest.xml"
   plugins:
     - custom_lint


### PR DESCRIPTION
This removes the linter warning about:

```warning • The default "android.hardware.touchscreen" needs to be optional for Chrome OS.  •```

from AndroidManifests for plugins, since only the merged app Manifest needs this.