### PR TITLE
Hid the devices serial number by default

### DIFF
--- a/lib/app/views/device_picker.dart
+++ b/lib/app/views/device_picker.dart
@@ -121,9 +121,7 @@ class DevicePickerContent extends ConsumerWidget {
 
 String _getDeviceInfoString(BuildContext context, DeviceInfo info) {
   final l10n = AppLocalizations.of(context);
-  final serial = info.serial;
   return [
-    if (serial != null) l10n.s_sn_serial(serial),
     if (info.version.isAtLeast(1))
       l10n.s_fw_version(info.getVersionName())
     else

--- a/lib/home/views/home_screen.dart
+++ b/lib/home/views/home_screen.dart
@@ -30,6 +30,7 @@ import '../../core/models.dart';
 import '../../core/state.dart';
 import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
+import '../../widgets/serial.dart';
 import 'key_actions.dart';
 import 'manage_label_dialog.dart';
 
@@ -308,11 +309,9 @@ class _DeviceContent extends ConsumerWidget {
         ),
         const SizedBox(height: 12),
         if (serial != null)
-          Text(
-            l10n.l_serial_number(serial),
-            style: Theme.of(context).textTheme.titleSmall?.apply(
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-            ),
+          Serial(
+            serial: serial,
+            l10n: l10n,
           ),
         if (version != const Version(0, 0, 0))
           Text(

--- a/lib/widgets/serial.dart
+++ b/lib/widgets/serial.dart
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2022 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import 'package:flutter/material.dart';
+
+import '../generated/l10n/app_localizations.dart';
+
+class Serial extends StatefulWidget {
+  final int serial;
+  final AppLocalizations l10n;
+
+  const Serial({required this.serial, required this.l10n, super.key});
+
+  @override
+  State<Serial> createState() => _SerialState();
+}
+
+class _SerialState extends State<Serial> {
+  bool _obscureText = true;
+  double _measureTextWidth(String text, TextStyle? style) {
+    final textPainter = TextPainter(
+      text: TextSpan(text: text, style: style),
+      maxLines: 1,
+      textDirection: TextDirection.ltr,
+    )..layout();
+
+    return textPainter.width;
+  }
+
+  void _handleTapDown(TapDownDetails details) {
+    setState(() {
+      _obscureText = false;
+    });
+  }
+
+  void _handleTapUp(TapUpDetails details) {
+    setState(() {
+      _obscureText = true;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final revealed = widget.l10n.l_serial_number(widget.serial);
+    
+  final obscured = widget.l10n.l_serial_number(widget.serial).replaceAllMapped(
+    RegExp(widget.serial.toString()),
+    (match) => '*' * match.group(0)!.length,
+  );
+
+    final textStyle = Theme.of(context).textTheme.titleSmall?.copyWith(
+      color: Theme.of(context).colorScheme.onSurfaceVariant,
+    );
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          width: _measureTextWidth(
+            revealed,
+            textStyle,
+          ), // Fixed width based on full text
+          child: Text(
+            _obscureText ? obscured : revealed,
+            style: textStyle,
+            overflow: TextOverflow.clip,
+          ),
+        ),
+        const SizedBox(width: 4),
+        GestureDetector(
+          onTapDown: _handleTapDown,
+          onTapUp: _handleTapUp,
+          child: Icon(
+            _obscureText ? Icons.visibility_off : Icons.remove_red_eye,
+            size: 20.0,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
I think the devices serial number should be hidden by default to allow users to prevent the leaking of identifiable information.

As they can choose obscure yet memorable usernames for the accounts of the TOTP authenticators, the only identifiable information that can't be hidden is the devices serial number.

I propose that a gesture detector should be added to the right of the serial number text UI, which toggles the visibility of the serial number when held downa and the serial number label in the device picker be removed.

Here are some screenshots of what I implemented:
<img width="1080" height="605" alt="Hidden" src="https://github.com/user-attachments/assets/5b088960-8400-451b-b9ff-1face689fa26" />
<img width="1080" height="605" alt="Visible" src="https://github.com/user-attachments/assets/a785c2c4-55b3-4f3e-a09e-e1623c0d0e2a" />

Resolves: #1944