### PR TITLE
[Linux] Fix window size handling

### DIFF
--- a/lib/desktop/init.dart
+++ b/lib/desktop/init.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2025 Yubico.
+ * Copyright (C) 2022-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,8 +68,15 @@ const String _hidden = 'hidden';
 const String _shown = 'shown';
 
 Timer? _saveWindowManagerPropertiesTimer;
+bool _isInitializingWindow = false;
 
 void _queueSaveWindowManagerProperties(WindowManagerHelper helper) {
+  // Guard: Don't save during initialization
+  if (_isInitializingWindow) {
+    _log.debug('Skipping save during window initialization');
+    return;
+  }
+
   _saveWindowManagerPropertiesTimer?.cancel();
   _saveWindowManagerPropertiesTimer = Timer(
     const Duration(
@@ -160,6 +167,8 @@ Future<Widget> initialize(List<String> argv) async {
         const WindowOptions(minimumSize: WindowDefaults.minSize),
       )
       .then((_) async {
+        _isInitializingWindow = true;
+
         await windowManagerHelper.restoreWindowManagerProperties();
 
         if (isHidden) {
@@ -171,6 +180,9 @@ Future<Widget> initialize(List<String> argv) async {
         screenRetriever.addListener(
           _ScreenRetrieverListener(windowManagerHelper),
         );
+
+        _isInitializingWindow = false;
+        _log.debug('Window initialization complete, saves enabled');
       });
 
   // Either use the _HELPER_PATH environment variable, or look relative to executable.

--- a/lib/desktop/init.dart
+++ b/lib/desktop/init.dart
@@ -169,20 +169,22 @@ Future<Widget> initialize(List<String> argv) async {
       .then((_) async {
         _isInitializingWindow = true;
 
-        await windowManagerHelper.restoreWindowManagerProperties();
+        try {
+          await windowManagerHelper.restoreWindowManagerProperties();
 
-        if (isHidden) {
-          await windowManager.setSkipTaskbar(true);
-        } else {
-          await windowManager.show();
+          if (isHidden) {
+            await windowManager.setSkipTaskbar(true);
+          } else {
+            await windowManager.show();
+          }
+          windowManager.addListener(_WindowEventListener(windowManagerHelper));
+          screenRetriever.addListener(
+            _ScreenRetrieverListener(windowManagerHelper),
+          );
+        } finally {
+          _isInitializingWindow = false;
+          _log.debug('Window initialization complete, saves enabled');
         }
-        windowManager.addListener(_WindowEventListener(windowManagerHelper));
-        screenRetriever.addListener(
-          _ScreenRetrieverListener(windowManagerHelper),
-        );
-
-        _isInitializingWindow = false;
-        _log.debug('Window initialization complete, saves enabled');
       });
 
   // Either use the _HELPER_PATH environment variable, or look relative to executable.

--- a/lib/desktop/window_manager_helper/_wm_helper_linux_impl.dart
+++ b/lib/desktop/window_manager_helper/_wm_helper_linux_impl.dart
@@ -16,15 +16,10 @@
 
 import 'dart:ui';
 
-import 'package:logging/logging.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:window_manager/window_manager.dart';
 
-import '../../app/logging.dart';
 import 'defaults.dart';
-import 'window_manager_helper.dart';
-
-final _log = Logger('wm_helper_linux');
 
 /// Linux-specific window manager implementation.
 ///
@@ -38,9 +33,7 @@ class WindowManagerHelperLinux {
   static Future<void> saveWindowManagerProperties(
     SharedPreferences prefs,
   ) async {
-    // Linux: No additional properties to save beyond size
-    // Position is not saved as it's controlled by the window manager
-    _log.debug('Saved Linux window manager properties (size only)');
+    // Linux: Currently no additional properties to save
   }
 
   static Future<void> restoreWindowManagerProperties(
@@ -52,21 +45,8 @@ class WindowManagerHelperLinux {
 
   static Future<void> setBounds(SharedPreferences prefs, Rect bounds) async {
     await windowManager.setMinimumSize(WindowDefaults.minSize);
-
-    // Validate size is reasonable
-    final width = bounds.width.clamp(
-      WindowDefaults.minSize.width,
-      WindowDefaults.maxWidth,
-    );
-    final height = bounds.height.clamp(
-      WindowDefaults.minSize.height,
-      WindowDefaults.maxHeight,
-    );
-
-    _log.debug('setBounds (size only): ${Size(width, height)}');
-
     // Only set size - position is controlled by window manager
-    await windowManager.setSize(Size(width, height));
+    await windowManager.setSize(bounds.size);
   }
 
   static Future<Rect> getBounds() async {
@@ -84,7 +64,6 @@ class WindowManagerHelperLinux {
       size.height,
     );
 
-    _log.debug('getBounds (size only): ${bounds.pretty}');
     return bounds;
   }
 }

--- a/lib/desktop/window_manager_helper/_wm_helper_linux_impl.dart
+++ b/lib/desktop/window_manager_helper/_wm_helper_linux_impl.dart
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'dart:ui';
+
+import 'package:logging/logging.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:window_manager/window_manager.dart';
+
+import '../../app/logging.dart';
+import 'defaults.dart';
+import 'window_manager_helper.dart';
+
+final _log = Logger('wm_helper_linux');
+
+/// Linux-specific window manager implementation.
+///
+/// IMPORTANT: Linux (especially Wayland) does NOT support window position APIs:
+/// - Wayland: gtk_window_get_position() always returns (0, 0)
+/// - X11: Position is unreliable due to window manager decorations
+///
+/// Therefore, this implementation only handles window SIZE, not position.
+/// Window positioning is controlled by the window manager on Linux.
+class WindowManagerHelperLinux {
+  static Future<void> saveWindowManagerProperties(
+    SharedPreferences prefs,
+  ) async {
+    // Linux: No additional properties to save beyond size
+    // Position is not saved as it's controlled by the window manager
+    _log.debug('Saved Linux window manager properties (size only)');
+  }
+
+  static Future<void> restoreWindowManagerProperties(
+    SharedPreferences prefs,
+    Rect bounds,
+  ) async {
+    await setBounds(prefs, bounds);
+  }
+
+  static Future<void> setBounds(SharedPreferences prefs, Rect bounds) async {
+    await windowManager.setMinimumSize(WindowDefaults.minSize);
+
+    // Validate size is reasonable
+    final width = bounds.width.clamp(
+      WindowDefaults.minSize.width,
+      WindowDefaults.maxWidth,
+    );
+    final height = bounds.height.clamp(
+      WindowDefaults.minSize.height,
+      WindowDefaults.maxHeight,
+    );
+
+    _log.debug('setBounds (size only): ${Size(width, height)}');
+
+    // Only set size - position is controlled by window manager
+    await windowManager.setSize(Size(width, height));
+  }
+
+  static Future<Rect> getBounds() async {
+    final size = await windowManager.getSize();
+
+    // Return size with default position (position not retrievable on Linux)
+    // See: https://docs.gtk.org/gtk3/method.Window.get_position.html
+    // "This function returns the position you need to pass to gtk_window_move()
+    // to keep window in its current position...On Wayland, this function always
+    // returns (0, 0)."
+    final bounds = Rect.fromLTWH(
+      WindowDefaults.bounds.left,
+      WindowDefaults.bounds.top,
+      size.width,
+      size.height,
+    );
+
+    _log.debug('getBounds (size only): ${bounds.pretty}');
+    return bounds;
+  }
+}

--- a/lib/desktop/window_manager_helper/window_manager_helper.dart
+++ b/lib/desktop/window_manager_helper/window_manager_helper.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2025 Yubico.
+ * Copyright (C) 2023-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:window_manager/window_manager.dart';
 
 import '../../app/logging.dart';
+import '_wm_helper_linux_impl.dart';
 import '_wm_helper_macos_impl.dart';
 import '_wm_helper_windows_impl.dart';
 import 'defaults.dart';
@@ -60,6 +61,10 @@ class WindowManagerHelper {
       await WindowManagerHelperWindows.saveWindowManagerProperties(
         sharedPreferences,
       );
+    } else if (Platform.isLinux) {
+      await WindowManagerHelperLinux.saveWindowManagerProperties(
+        sharedPreferences,
+      );
     }
 
     _log.debug('Window manager properties saved.');
@@ -94,6 +99,11 @@ class WindowManagerHelper {
         sharedPreferences,
         bounds,
       );
+    } else if (Platform.isLinux) {
+      await WindowManagerHelperLinux.restoreWindowManagerProperties(
+        sharedPreferences,
+        bounds,
+      );
     }
   }
 
@@ -103,6 +113,8 @@ class WindowManagerHelper {
       return await WindowManagerHelperMacOs.getBounds();
     } else if (Platform.isWindows) {
       return await WindowManagerHelperWindows.getBounds();
+    } else if (Platform.isLinux) {
+      return await WindowManagerHelperLinux.getBounds();
     } else {
       final size = await windowManager.getSize();
       return Rect.fromLTWH(
@@ -120,6 +132,8 @@ class WindowManagerHelper {
       await WindowManagerHelperMacOs.setBounds(sharedPreferences, rect);
     } else if (Platform.isWindows) {
       await WindowManagerHelperWindows.setBounds(sharedPreferences, rect);
+    } else if (Platform.isLinux) {
+      await WindowManagerHelperLinux.setBounds(sharedPreferences, rect);
     } else {
       await windowManager.setSize(rect.size);
     }


### PR DESCRIPTION
This pull request adds Linux support to the window management helper, ensuring consistent window size handling across platforms. It introduces a Linux-specific implementation that manages window size (not position, due to platform limitations), and updates the initialization logic to prevent saving window properties during the initial setup.

Tested on Ubuntu 25.10 with GNOME.

Fixes #2116


