### PR TITLE
Ask for permission to store PPUAT

### DIFF
--- a/helper/helper/fido.py
+++ b/helper/helper/fido.py
@@ -72,7 +72,7 @@ class Ctap2Node(RpcNode):
 
     @classmethod
     def _get_ppuats(cls):
-        if not cls._ppuats:
+        if cls._ppuats is None:
             cls._ppuats = AppData("ppuats")
         return cls._ppuats
 
@@ -92,6 +92,7 @@ class Ctap2Node(RpcNode):
     def _get_ppuat(self) -> bytes | None:
         if (
             CredentialManagement.is_readonly_supported(self._info)
+            and len(self._get_ppuats()) > 0
             and self._unlock_ppuat_store()
         ):
             ppuats = self._get_ppuats()
@@ -199,7 +200,7 @@ class Ctap2Node(RpcNode):
         return RpcResponse(dict(), ["device_info", "device_closed"])
 
     @action(condition=lambda self: self._info.options["clientPin"])
-    def unlock(self, pin: str):
+    def unlock(self, pin: str, remember: bool = False):
         permissions = ClientPin.PERMISSION(0)
         if CredentialManagement.is_supported(self._info):
             permissions |= ClientPin.PERMISSION.CREDENTIAL_MGMT
@@ -208,8 +209,10 @@ class Ctap2Node(RpcNode):
         if Config.is_supported(self._info):
             permissions |= ClientPin.PERMISSION.AUTHENTICATOR_CFG
         try:
-            if not self._ppuat and CredentialManagement.is_readonly_supported(
-                self._info
+            if (
+                remember
+                and not self._ppuat
+                and CredentialManagement.is_readonly_supported(self._info)
             ):
                 self._ppuat = self.client_pin.get_pin_token(
                     pin, ClientPin.PERMISSION.PERSISTENT_CREDENTIAL_MGMT
@@ -240,6 +243,7 @@ class Ctap2Node(RpcNode):
             else:
                 self.client_pin.set_pin(new_pin)
             self._info = self.ctap.get_info()
+            self._delete_ppuat()
             return RpcResponse(dict(), ["device_info"])
         except CtapError as e:
             self._token = None

--- a/helper/helper/oath.py
+++ b/helper/helper/oath.py
@@ -47,7 +47,7 @@ class OathNode(RpcNode):
 
     @classmethod
     def _get_keys(cls):
-        if not cls._oath_keys:
+        if cls._oath_keys is None:
             cls._oath_keys = AppData("oath_keys")
         return cls._oath_keys
 

--- a/lib/android/fido/state.dart
+++ b/lib/android/fido/state.dart
@@ -141,8 +141,9 @@ class AndroidFidoStateNotifier extends FidoStateNotifier {
     }
   }
 
+  // TODO: implement remember on Android
   @override
-  Future<PinResult> unlock(String pin) async {
+  Future<PinResult> unlock(String pin, {bool remember = false}) async {
     try {
       final response = jsonDecode(await fido.invoke('unlock', {'pin': pin}));
 

--- a/lib/desktop/fido/state.dart
+++ b/lib/desktop/fido/state.dart
@@ -216,9 +216,12 @@ class DesktopFidoStateNotifier extends FidoStateNotifier {
   }
 
   @override
-  Future<PinResult> unlock(String pin) async {
+  Future<PinResult> unlock(String pin, {bool remember = false}) async {
     try {
-      await _session.command('unlock', params: {'pin': pin});
+      await _session.command(
+        'unlock',
+        params: {'pin': pin, 'remember': remember},
+      );
       _pinController.state = pin;
 
       return PinResult.success();

--- a/lib/fido/models.dart
+++ b/lib/fido/models.dart
@@ -54,6 +54,8 @@ abstract class FidoState with _$FidoState {
   bool get pinBlocked => pinRetries == 0;
 
   bool? get enterpriseAttestation => info['options']['ep'];
+
+  bool get readOnlySupported => info['options']['perCredMgmtRO'] == true;
 }
 
 @freezed

--- a/lib/fido/state.dart
+++ b/lib/fido/state.dart
@@ -58,7 +58,7 @@ abstract class FidoStateNotifier extends ApplicationStateNotifier<FidoState> {
 
   Stream<InteractionEvent> reset();
   Future<PinResult> setPin(String newPin, {String? oldPin});
-  Future<PinResult> unlock(String pin);
+  Future<PinResult> unlock(String pin, {bool remember = false});
   Future<void> enableEnterpriseAttestation();
 }
 

--- a/lib/fido/views/pin_entry_form.dart
+++ b/lib/fido/views/pin_entry_form.dart
@@ -47,6 +47,7 @@ class _PinEntryFormState extends ConsumerState<PinEntryForm> {
   int? _retries;
   bool _pinIsWrong = false;
   bool _isObscure = true;
+  bool _remember = false;
 
   @override
   void initState() {
@@ -71,7 +72,7 @@ class _PinEntryFormState extends ConsumerState<PinEntryForm> {
     try {
       final result = await ref
           .read(fidoStateProvider(widget._deviceData.node.path).notifier)
-          .unlock(_pinController.text);
+          .unlock(_pinController.text, remember: _remember);
       switch (result) {
         case PinResultFailure(:final reason):
           {
@@ -120,6 +121,7 @@ class _PinEntryFormState extends ConsumerState<PinEntryForm> {
     final noFingerprints = widget._state.bioEnroll == false;
     final authBlocked = widget._state.pinBlocked;
     final pinRetries = widget._state.pinRetries;
+    final readOnlySupported = widget._state.readOnlySupported;
     return Padding(
       padding: const EdgeInsets.only(left: 18.0, right: 18, top: 8),
       child: Column(
@@ -205,32 +207,85 @@ class _PinEntryFormState extends ConsumerState<PinEntryForm> {
               },
             ).init(),
           ),
-          ListTile(
-            leading: noFingerprints
-                ? Icon(
-                    Symbols.warning_amber,
-                    color: Theme.of(context).colorScheme.tertiary,
-                  )
-                : null,
-            title: noFingerprints
-                ? Text(l10n.l_no_fps_added, overflow: .fade)
-                : null,
-            dense: true,
-            contentPadding: const EdgeInsets.symmetric(horizontal: 0),
-            minLeadingWidth: 0,
-            trailing: FilledButton.icon(
-              key: unlockFido2WithPin,
-              icon: const Icon(Symbols.lock_open),
-              label: Text(l10n.s_unlock),
-              onPressed:
-                  !_pinIsWrong &&
-                      _pinController.text.length >=
-                          widget._state.minPinLength &&
-                      !_blocked
-                  ? _submit
-                  : null,
-            ),
-          ),
+          readOnlySupported
+              ? Column(
+                  crossAxisAlignment: .stretch,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.only(left: 40),
+                      child: Wrap(
+                        alignment: .spaceBetween,
+                        crossAxisAlignment: .center,
+                        spacing: 4.0,
+                        runSpacing: 8.0,
+                        children: [
+                          FilterChip(
+                            label: Text(l10n.s_persist_read_only_access),
+                            selected: _remember,
+                            onSelected: (value) {
+                              setState(() {
+                                _remember = value;
+                              });
+                            },
+                          ),
+                          FilledButton.icon(
+                            key: unlockFido2WithPin,
+                            icon: const Icon(Symbols.lock_open),
+                            label: Text(l10n.s_unlock),
+                            onPressed:
+                                !_pinIsWrong &&
+                                    _pinController.text.length >=
+                                        widget._state.minPinLength &&
+                                    !_blocked
+                                ? _submit
+                                : null,
+                          ),
+                        ],
+                      ),
+                    ),
+                    if (noFingerprints) ...[
+                      const SizedBox(height: 8.0),
+                      ListTile(
+                        leading: Icon(
+                          Symbols.warning_amber,
+                          color: Theme.of(context).colorScheme.tertiary,
+                        ),
+                        title: Text(l10n.l_no_fps_added, overflow: .fade),
+                        dense: true,
+                        contentPadding: const EdgeInsets.symmetric(
+                          horizontal: 0,
+                        ),
+                        minLeadingWidth: 0,
+                      ),
+                    ],
+                  ],
+                )
+              : ListTile(
+                  leading: noFingerprints
+                      ? Icon(
+                          Symbols.warning_amber,
+                          color: Theme.of(context).colorScheme.tertiary,
+                        )
+                      : null,
+                  title: noFingerprints
+                      ? Text(l10n.l_no_fps_added, overflow: .fade)
+                      : null,
+                  dense: true,
+                  contentPadding: const EdgeInsets.symmetric(horizontal: 0),
+                  minLeadingWidth: 0,
+                  trailing: FilledButton.icon(
+                    key: unlockFido2WithPin,
+                    icon: const Icon(Symbols.lock_open),
+                    label: Text(l10n.s_unlock),
+                    onPressed:
+                        !_pinIsWrong &&
+                            _pinController.text.length >=
+                                widget._state.minPinLength &&
+                            !_blocked
+                        ? _submit
+                        : null,
+                  ),
+                ),
         ],
       ),
     );

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -346,6 +346,7 @@
             }
         }
     },
+    "s_persist_read_only_access": null,
     "s_ep_attestation": "Ověření podniku",
     "s_ep_attestation_enabled": "Ověření podniku je povoleno",
     "q_enable_ep_attestation": "Povolit ověření podniku?",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -346,6 +346,7 @@
             }
         }
     },
+    "s_persist_read_only_access": null,
     "s_ep_attestation": "Enterprise Attestation",
     "s_ep_attestation_enabled": "Enterprise Attestation aktiviert",
     "q_enable_ep_attestation": "Enterprise Attestation aktivieren?",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -346,6 +346,7 @@
             }
         }
     },
+    "s_persist_read_only_access": null,
     "s_ep_attestation": "Εταιρική Πιστοποίηση (Enterprise Attestation)",
     "s_ep_attestation_enabled": "Η Εταιρική Πιστοποίηση είναι ενεργοποιημένη",
     "q_enable_ep_attestation": "Ενεργοποίηση Εταιρικής Πιστοποίησης;",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -346,6 +346,7 @@
             }
         }
     },
+    "s_persist_read_only_access": "Persist read-only access",
     "s_ep_attestation": "Enterprise Attestation",
     "s_ep_attestation_enabled": "Enterprise Attestation enabled",
     "q_enable_ep_attestation": "Enable Enterprise Attestation?",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -346,6 +346,7 @@
             }
         }
     },
+    "s_persist_read_only_access": null,
     "s_ep_attestation": "Atestación empresarial",
     "s_ep_attestation_enabled": "Atestación empresarial habilitada",
     "q_enable_ep_attestation": "¿Habilitar atestación empresarial?",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -346,6 +346,7 @@
             }
         }
     },
+    "s_persist_read_only_access": null,
     "s_ep_attestation": "Attestation d'entreprise",
     "s_ep_attestation_enabled": "Attestation d'entreprise activée",
     "q_enable_ep_attestation": "Activer l'Attestation d'Entreprise ?",

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -346,6 +346,7 @@
             }
         }
     },
+    "s_persist_read_only_access": null,
     "s_ep_attestation": "Vállalati tanúsítás",
     "s_ep_attestation_enabled": "Vállalati tanúsítás engedélyezve",
     "q_enable_ep_attestation": "Engedélyezze a vállalati tanúsítást?",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -346,6 +346,7 @@
             }
         }
     },
+    "s_persist_read_only_access": null,
     "s_ep_attestation": "Attestazione aziendale",
     "s_ep_attestation_enabled": "Attestazione aziendale abilitata",
     "q_enable_ep_attestation": "Abilitare l'attestazione aziendale?",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -346,6 +346,7 @@
             }
         }
     },
+    "s_persist_read_only_access": null,
     "s_ep_attestation": "Enterprise Attestation",
     "s_ep_attestation_enabled": "Enterprise Attestation が有効です",
     "q_enable_ep_attestation": "Enterprise Attestation を有効にしますか？",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -346,6 +346,7 @@
             }
         }
     },
+    "s_persist_read_only_access": null,
     "s_ep_attestation": "Bedrijf herkenning",
     "s_ep_attestation_enabled": "Bedrijfsherkenning ingeschakeld",
     "q_enable_ep_attestation": "Bedrijfsherkenning inschakelen?",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -346,6 +346,7 @@
             }
         }
     },
+    "s_persist_read_only_access": null,
     "s_ep_attestation": "Atest przedsiębiorstwa",
     "s_ep_attestation_enabled": "Atest przedsiębiorstwa został włączony",
     "q_enable_ep_attestation": "Włączyć atest przedsiębiorstwa?",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -346,6 +346,7 @@
             }
         }
     },
+    "s_persist_read_only_access": null,
     "s_ep_attestation": "Atestado Corporativo",
     "s_ep_attestation_enabled": "Atestação Empresarial habilitado",
     "q_enable_ep_attestation": "Habilitar Certificação Empresarial?",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -346,6 +346,7 @@
             }
         }
     },
+    "s_persist_read_only_access": null,
     "s_ep_attestation": "Корпоративная Аттестация",
     "s_ep_attestation_enabled": "Включена Корпоративная Аттестация",
     "q_enable_ep_attestation": "Включить Корпоративную Аттестацию?",

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -346,6 +346,7 @@
             }
         }
     },
+    "s_persist_read_only_access": null,
     "s_ep_attestation": "Podniková atestácia",
     "s_ep_attestation_enabled": "Podniková atestácia povolená",
     "q_enable_ep_attestation": "Povoliť podnikovú atestáciu?",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -346,6 +346,7 @@
             }
         }
     },
+    "s_persist_read_only_access": null,
     "s_ep_attestation": "Företagsintyg",
     "s_ep_attestation_enabled": "Företagsattestering aktiverad",
     "q_enable_ep_attestation": "Aktivera Enterprise Attestation?",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -346,6 +346,7 @@
             }
         }
     },
+    "s_persist_read_only_access": null,
     "s_ep_attestation": "Kurumsal Doğrulama",
     "s_ep_attestation_enabled": "Kurumsal Doğrulama etkinleştirildi",
     "q_enable_ep_attestation": "Kurumsal Doğrulama etkinleştirilsin mi?",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -346,6 +346,7 @@
             }
         }
     },
+    "s_persist_read_only_access": null,
     "s_ep_attestation": "Атестація підприємства",
     "s_ep_attestation_enabled": "Атестацію підприємства ввімкнено",
     "q_enable_ep_attestation": "Увімкнути корпоративну атестацію?",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -346,6 +346,7 @@
             }
         }
     },
+    "s_persist_read_only_access": null,
     "s_ep_attestation": "Xác thực Doanh Nghiệp",
     "s_ep_attestation_enabled": "Xác thực Doanh Nghiệp đã được kích hoạt",
     "q_enable_ep_attestation": "Bật tính năng Chứng thực cấp tổ chức?",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -346,6 +346,7 @@
             }
         }
     },
+    "s_persist_read_only_access": null,
     "s_ep_attestation": "企业认证",
     "s_ep_attestation_enabled": "企业认证已启用",
     "q_enable_ep_attestation": "启用企业认证？",

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -346,6 +346,7 @@
             }
         }
     },
+    "s_persist_read_only_access": null,
     "s_ep_attestation": "企業驗證",
     "s_ep_attestation_enabled": "企業驗證已啟用",
     "q_enable_ep_attestation": "啟用企業驗證？",


### PR DESCRIPTION
This adds a checkbox to the FIDO unlock form, where the user can decided wether to store the PPUAT or not. 

NOTE: this is only implemented on desktop.