### PR TITLE
fix: set explicitChildNodes to true

### DIFF
--- a/lib/app/message.dart
+++ b/lib/app/message.dart
@@ -55,8 +55,12 @@ Future<T?> showBlurDialog<T>({
   barrierDismissible: true,
   barrierColor: barrierColor,
   barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
-  pageBuilder: (ctx, anim1, anim2) =>
-      Semantics(scopesRoute: true, explicitChildNodes: true, namesRoute: true, child: builder(ctx)),
+  pageBuilder: (ctx, anim1, anim2) => Semantics(
+    scopesRoute: true,
+    explicitChildNodes: true,
+    namesRoute: true,
+    child: builder(ctx),
+  ),
   transitionDuration: const Duration(milliseconds: 150),
   transitionBuilder: (ctx, anim1, anim2, child) => BackdropFilter(
     filter: ImageFilter.blur(

--- a/lib/app/message.dart
+++ b/lib/app/message.dart
@@ -56,7 +56,7 @@ Future<T?> showBlurDialog<T>({
   barrierColor: barrierColor,
   barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
   pageBuilder: (ctx, anim1, anim2) =>
-      Semantics(scopesRoute: true, namesRoute: true, child: builder(ctx)),
+      Semantics(scopesRoute: true, explicitChildNodes: true, namesRoute: true, child: builder(ctx)),
   transitionDuration: const Duration(milliseconds: 150),
   transitionBuilder: (ctx, anim1, anim2, child) => BackdropFilter(
     filter: ImageFilter.blur(


### PR DESCRIPTION
Flutter's semantics framework requires that when scopesRoute is true, explicitChildNodes must also be set to true.
