### PR TITLE
a11y: Remove focus borders on Android and extract to FocusBorder widget

### DIFF
--- a/lib/app/views/action_list.dart
+++ b/lib/app/views/action_list.dart
@@ -18,6 +18,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/state.dart';
+import '../../widgets/focus_border.dart';
 import '../../widgets/list_title.dart';
 import '../../widgets/tooltip_if_truncated.dart';
 import '../models.dart';
@@ -70,18 +71,9 @@ class _ActionListItemState extends State<ActionListItem> {
               // on a disabled item
             }
           : null,
-      child: ListenableBuilder(
-        listenable: _focusNode,
-        builder: (context, child) => DecoratedBox(
-          position: DecorationPosition.foreground,
-          decoration: BoxDecoration(
-            border: _focusNode.hasFocus
-                ? Border.all(color: colorScheme.primary, width: 1)
-                : null,
-            borderRadius: borderRadius,
-          ),
-          child: child!,
-        ),
+      child: FocusBorder(
+        focusNode: _focusNode,
+        borderRadius: borderRadius,
         child: ListTile(
           focusNode: _focusNode,
           shape: RoundedRectangleBorder(borderRadius: borderRadius),

--- a/lib/app/views/app_list_item.dart
+++ b/lib/app/views/app_list_item.dart
@@ -18,6 +18,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/state.dart';
+import '../../widgets/focus_border.dart';
 import '../models.dart';
 import '../shortcuts.dart';
 import 'action_popup_menu.dart';
@@ -83,18 +84,9 @@ class _AppListItemState<T> extends ConsumerState<AppListItem> {
       selected: widget.selected,
       child: ItemShortcuts<T>(
         item: widget.item,
-        child: ListenableBuilder(
-          listenable: _focusNode,
-          builder: (context, child) => DecoratedBox(
-            position: DecorationPosition.foreground,
-            decoration: BoxDecoration(
-              border: _focusNode.hasFocus
-                  ? Border.all(color: colorScheme.primary, width: 1)
-                  : null,
-              borderRadius: BorderRadius.circular(16),
-            ),
-            child: child!,
-          ),
+        child: FocusBorder(
+          focusNode: _focusNode,
+          borderRadius: BorderRadius.circular(16),
           child: InkWell(
             focusNode: _focusNode,
             borderRadius: BorderRadius.circular(16),

--- a/lib/app/views/device_picker.dart
+++ b/lib/app/views/device_picker.dart
@@ -24,6 +24,7 @@ import '../../android/state.dart';
 import '../../core/state.dart';
 import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
+import '../../widgets/focus_border.dart';
 import '../models.dart';
 import '../state.dart';
 import 'device_avatar.dart';
@@ -280,23 +281,12 @@ class _DeviceRowState extends ConsumerState<DeviceRow> {
                 _showContextMenu = false;
               });
             },
-            child: ListenableBuilder(
-              listenable: _focusNode,
-              builder: (context, child) => DecoratedBox(
-                position: DecorationPosition.foreground,
-                decoration: BoxDecoration(
-                  border: _focusNode.hasFocus
-                      ? Border.all(
-                          color: widget.selected
-                              ? colorScheme.onPrimary
-                              : themeData.colorScheme.primary,
-                          width: 1,
-                        )
-                      : null,
-                  borderRadius: borderRadius,
-                ),
-                child: child!,
-              ),
+            child: FocusBorder(
+              focusNode: _focusNode,
+              borderRadius: borderRadius,
+              color: widget.selected
+                  ? colorScheme.onPrimary
+                  : themeData.colorScheme.primary,
               child: ListTile(
                 focusNode: _focusNode,
                 shape: RoundedRectangleBorder(borderRadius: borderRadius),

--- a/lib/app/views/navigation.dart
+++ b/lib/app/views/navigation.dart
@@ -22,6 +22,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../generated/l10n/app_localizations.dart';
+import '../../widgets/focus_border.dart';
 import '../models.dart';
 import '../state.dart';
 import 'device_picker.dart';
@@ -93,18 +94,9 @@ class _NavigationItemState extends State<NavigationItem> {
       );
     } else {
       final borderRadius = widget.borderRadius ?? BorderRadius.circular(48);
-      return ListenableBuilder(
-        listenable: _focusNode,
-        builder: (context, child) => DecoratedBox(
-          position: DecorationPosition.foreground,
-          decoration: BoxDecoration(
-            border: _focusNode.hasFocus
-                ? Border.all(color: colorScheme.primary, width: 1)
-                : null,
-            borderRadius: borderRadius,
-          ),
-          child: child!,
-        ),
+      return FocusBorder(
+        focusNode: _focusNode,
+        borderRadius: borderRadius,
         child: ListTile(
           focusNode: _focusNode,
           enabled: widget.onTap != null,

--- a/lib/home/views/home_screen.dart
+++ b/lib/home/views/home_screen.dart
@@ -32,6 +32,7 @@ import '../../core/models.dart';
 import '../../core/state.dart';
 import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
+import '../../widgets/focus_border.dart';
 import 'key_actions.dart';
 import 'manage_label_dialog.dart';
 
@@ -427,7 +428,6 @@ class _ColorButtonState extends State<_ColorButton> {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
     final iconColor =
         ThemeData.estimateBrightnessForColor(widget.color) == Brightness.light
         ? Colors.black.withValues(alpha: 0.6)
@@ -437,18 +437,9 @@ class _ColorButtonState extends State<_ColorButton> {
       label: widget.colorName,
       onTap: widget.onPressed,
       selected: widget.isSelected,
-      child: ListenableBuilder(
-        listenable: _focusNode,
-        builder: (context, child) => DecoratedBox(
-          position: DecorationPosition.foreground,
-          decoration: BoxDecoration(
-            shape: BoxShape.circle,
-            border: _focusNode.hasFocus
-                ? Border.all(color: colorScheme.primary, width: 1)
-                : null,
-          ),
-          child: child!,
-        ),
+      child: FocusBorder(
+        focusNode: _focusNode,
+        shape: BoxShape.circle,
         child: ExcludeSemantics(
           excluding: isAndroid,
           child: RawMaterialButton(

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -16,6 +16,8 @@
 
 import 'package:flutter/material.dart';
 
+import 'core/state.dart';
+
 const defaultPrimaryColor = Colors.lightGreen;
 
 class AppTheme {
@@ -57,7 +59,7 @@ class AppTheme {
 
   static ThemeData _themeData(Brightness brightness, Color primaryColor) {
     final colorScheme = _colorScheme(brightness, primaryColor);
-    final focusBorder = _focusBorderSide(colorScheme);
+    final focusBorder = isAndroid ? null : _focusBorderSide(colorScheme);
     final focusButtonStyle = ButtonStyle(side: focusBorder);
 
     return ThemeData(
@@ -76,7 +78,7 @@ class AppTheme {
           color: colorScheme.onSurface,
         ),
         side: WidgetStateBorderSide.resolveWith((states) {
-          if (states.contains(WidgetState.focused)) {
+          if (!isAndroid && states.contains(WidgetState.focused)) {
             return BorderSide(color: colorScheme.primary);
           }
           if (states.contains(WidgetState.disabled)) {

--- a/lib/widgets/focus_border.dart
+++ b/lib/widgets/focus_border.dart
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'package:flutter/material.dart';
+
+import '../core/state.dart';
+
+/// Draws a 1px foreground border around [child] when [focusNode] has focus,
+/// using [color] (or [ColorScheme.primary] when omitted).
+///
+/// The border is never drawn on Android.
+class FocusBorder extends StatelessWidget {
+  final FocusNode focusNode;
+  final Widget child;
+
+  /// Border shape. Defaults to [BoxShape.rectangle].
+  final BoxShape shape;
+
+  /// Corner radius applied when [shape] is [BoxShape.rectangle].
+  /// Ignored for [BoxShape.circle].
+  final BorderRadiusGeometry? borderRadius;
+
+  /// Overrides the border color. Defaults to [ColorScheme.primary].
+  final Color? color;
+
+  const FocusBorder({
+    super.key,
+    required this.focusNode,
+    required this.child,
+    this.shape = BoxShape.rectangle,
+    this.borderRadius,
+    this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final resolvedColor = color ?? Theme.of(context).colorScheme.primary;
+    return ListenableBuilder(
+      listenable: focusNode,
+      builder: (context, child) => DecoratedBox(
+        position: DecorationPosition.foreground,
+        decoration: BoxDecoration(
+          shape: shape,
+          border: !isAndroid && focusNode.hasFocus
+              ? Border.all(color: resolvedColor, width: 1)
+              : null,
+          borderRadius: shape == BoxShape.circle ? null : borderRadius,
+        ),
+        child: child!,
+      ),
+      child: child,
+    );
+  }
+}


### PR DESCRIPTION
This pull request introduces a new reusable `FocusBorder` widget to centralize and standardize how focus borders are rendered across the application. The widget replaces repeated focus border logic in multiple UI components, leading to cleaner and more maintainable code. Additionally, focus borders are now consistently suppressed on Android devices, both in the new widget and in theme definitions, to align with platform conventions.

The most important changes are:

**Introduction of `FocusBorder` widget:**
* Added a new `FocusBorder` widget in `lib/widgets/focus_border.dart` that draws a 1px border around its child when focused, except on Android. The widget supports customization of shape, border radius, and color.

**Refactoring to use `FocusBorder`:**
* Replaced custom focus border logic (using `ListenableBuilder` and `DecoratedBox`) with the new `FocusBorder` widget in the following files and widgets:
  - `ActionListItem` in `lib/app/views/action_list.dart`
  - `AppListItem` in `lib/app/views/app_list_item.dart`
  - `DeviceRow` in `lib/app/views/device_picker.dart`
  - `NavigationItem` in `lib/app/views/navigation.dart`
  - `_ColorButton` in `lib/home/views/home_screen.dart`

**Imports and code cleanup:**
* Added imports for `focus_border.dart` in all affected files to support the refactor. [[1]](diffhunk://#diff-04f07842784e49ad8387ff0c8e15b14994a1871bd07d7a69bf76610411dabfeeR21) [[2]](diffhunk://#diff-2fbf71946ab2dbece67ef62a76a10f91c75b323a3124c363993e2ec43727a734R21) [[3]](diffhunk://#diff-2c112e86d002c1654d7cc8bdb89cc0e1c3e6f7afaa126b70de6b76162e12d6deR27) [[4]](diffhunk://#diff-d4d84ec3a959048fb422de82a8a6c5d7641e608ee2847393567ddcf9c73e9314R25) [[5]](diffhunk://#diff-177640f7e006ca7328e31c332845cabb01e47018cd5c883f8d1bbaa730d5c3a1R35)
* Removed now-unnecessary local focus border logic and related variables in affected widgets.

**Platform-specific focus border handling:**
* Updated `AppTheme` in `lib/theme.dart` so that focus borders are not applied on Android, both in the theme's border side logic and in button styles. [[1]](diffhunk://#diff-426fde79c525f8cdaabb9293e9df1134d1b8cb13cd8d1608322dd60aa40d7af2R19-R20) [[2]](diffhunk://#diff-426fde79c525f8cdaabb9293e9df1134d1b8cb13cd8d1608322dd60aa40d7af2L60-R62) [[3]](diffhunk://#diff-426fde79c525f8cdaabb9293e9df1134d1b8cb13cd8d1608322dd60aa40d7af2L79-R81)

These changes result in more consistent focus border behavior, easier future maintenance, and improved platform-specific UI adherence.