### PR TITLE
[Android] Support landscape orientation

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -17,10 +17,6 @@
         android:name="android.hardware.touchscreen"
         android:required="false" />
 
-    <uses-feature
-        android:name="android.hardware.screen.portrait"
-        android:required="false" />
-
     <application
         android:name="${applicationName}"
         android:enableOnBackInvokedCallback="true"

--- a/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2025 Yubico.
+ * Copyright (C) 2022-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,13 @@
 
 package com.yubico.authenticator
 
-import android.annotation.SuppressLint
 import android.app.Application
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener
-import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
-import android.content.res.Configuration
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager
 import android.hardware.usb.UsbDevice
@@ -135,10 +132,6 @@ class MainActivity : FlutterFragmentActivity() {
 
         Security.removeProvider("BC")
         Security.insertProviderAt(BouncyCastleProvider(), 1)
-
-        if (isPortraitOnly()) {
-            forcePortraitOrientation()
-        }
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
@@ -317,17 +310,6 @@ class MainActivity : FlutterFragmentActivity() {
         appPreferences.registerListener(sharedPreferencesListener)
 
         preserveConnectionOnPause = false
-    }
-
-    override fun onMultiWindowModeChanged(isInMultiWindowMode: Boolean, newConfig: Configuration) {
-        super.onMultiWindowModeChanged(isInMultiWindowMode, newConfig)
-
-        if (isPortraitOnly()) {
-            when (isInMultiWindowMode) {
-                true -> allowAnyOrientation()
-                else -> forcePortraitOrientation()
-            }
-        }
     }
 
     private suspend fun processYubiKey(device: YubiKeyDevice) {
@@ -821,17 +803,6 @@ class MainActivity : FlutterFragmentActivity() {
         }
         return null
     }
-
-    @SuppressLint("SourceLockedOrientationActivity")
-    private fun forcePortraitOrientation() {
-        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-    }
-
-    private fun allowAnyOrientation() {
-        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
-    }
-
-    private fun isPortraitOnly() = resources.getBoolean(R.bool.portrait_only)
 
     private val defaultLogLevel =
         if (BuildConfig.DEBUG) Log.LogLevel.TRAFFIC else Log.LogLevel.INFO

--- a/android/app/src/main/res/values-sw600dp/bools.xml
+++ b/android/app/src/main/res/values-sw600dp/bools.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <bool name="portrait_only">false</bool>
-</resources>

--- a/android/app/src/main/res/values/bools.xml
+++ b/android/app/src/main/res/values/bools.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <bool name="portrait_only">true</bool>
-</resources>

--- a/lib/app/views/app_page.dart
+++ b/lib/app/views/app_page.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2025 Yubico.
+ * Copyright (C) 2022-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
+
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -29,6 +30,7 @@ import '../../core/state.dart';
 import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 import '../../widgets/delayed_visibility.dart';
+import '../../widgets/ensure_focus_visible.dart';
 import '../../widgets/file_drop_target.dart';
 import '../message.dart';
 import '../shortcuts.dart';
@@ -483,7 +485,7 @@ class _AppPageState extends ConsumerState<AppPage> {
                           parent: AlwaysScrollableScrollPhysics(),
                         )
                       : null,
-                  child: safeArea,
+                  child: EnsureFocusVisible(child: safeArea),
                 ),
               ),
             ),
@@ -519,23 +521,31 @@ class _AppPageState extends ConsumerState<AppPage> {
               slivers: [
                 SliverPersistentHeader(
                   pinned: true,
-                  delegate: _SliverTitleDelegate(
-                    child: ColoredBox(
-                      color: Theme.of(context).colorScheme.surface,
-                      child: Padding(
-                        key: _sliverTitleWrapperGlobalKey,
-                        padding: const EdgeInsets.only(
-                          left: 18.0,
-                          right: 18.0,
-                          bottom: 12.0,
-                          top: 4.0,
-                        ),
-                        child: _buildTitle(context),
-                      ),
-                    ),
-                    // Header height = title height + vertical padding
-                    height: _getTitleHeight(context) + 16,
-                  ),
+                  delegate: () {
+                    final isLandscape =
+                        isAndroid &&
+                        MediaQuery.of(context).orientation ==
+                            Orientation.landscape;
+                    return _SliverTitleDelegate(
+                      child: isLandscape
+                          ? const SizedBox.shrink()
+                          : ColoredBox(
+                              color: Theme.of(context).colorScheme.surface,
+                              child: Padding(
+                                key: _sliverTitleWrapperGlobalKey,
+                                padding: const EdgeInsets.only(
+                                  left: 18.0,
+                                  right: 18.0,
+                                  bottom: 12.0,
+                                  top: 4.0,
+                                ),
+                                child: _buildTitle(context),
+                              ),
+                            ),
+                      // Header height = title height + vertical padding
+                      height: isLandscape ? 0 : _getTitleHeight(context) + 16,
+                    );
+                  }(),
                 ),
                 if (widget.headerSliver != null)
                   SliverToBoxAdapter(
@@ -551,16 +561,25 @@ class _AppPageState extends ConsumerState<AppPage> {
                           _sliverTitleWrapperGlobalKey,
                         );
 
-                        return Container(
-                          key: headerSliverGlobalKey,
-                          child: widget.headerSliver,
+                        return EnsureFocusVisible(
+                          child: Container(
+                            key: headerSliverGlobalKey,
+                            child: widget.headerSliver,
+                          ),
                         );
                       },
                     ),
                   ),
               ],
             ),
-            SliverToBoxAdapter(child: safeArea),
+            SliverToBoxAdapter(child: EnsureFocusVisible(child: safeArea)),
+            // Extra space so content can scroll above the software keyboard
+            if (isAndroid)
+              SliverToBoxAdapter(
+                child: SizedBox(
+                  height: MediaQuery.of(context).viewInsets.bottom,
+                ),
+              ),
           ],
         ),
       );
@@ -571,7 +590,7 @@ class _AppPageState extends ConsumerState<AppPage> {
           ? const ClampingScrollPhysics(parent: AlwaysScrollableScrollPhysics())
           : null,
       primary: false,
-      child: safeArea,
+      child: EnsureFocusVisible(child: safeArea),
     );
   }
 

--- a/lib/fido/views/add_fingerprint_dialog.dart
+++ b/lib/fido/views/add_fingerprint_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2025 Yubico.
+ * Copyright (C) 2022-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/widgets/ensure_focus_visible.dart
+++ b/lib/widgets/ensure_focus_visible.dart
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'package:flutter/material.dart';
+
+import '../core/state.dart';
+
+/// Wraps a child and automatically scrolls to bring the focused widget
+/// into view when the keyboard appears, disappears, or the screen rotates.
+///
+/// Only active on Android. On desktop platforms this is a no-op passthrough.
+/// Must be placed inside a [SingleChildScrollView] (or any [Scrollable]).
+class EnsureFocusVisible extends StatefulWidget {
+  final Widget child;
+  const EnsureFocusVisible({super.key, required this.child});
+
+  @override
+  State<EnsureFocusVisible> createState() => _EnsureFocusVisibleState();
+}
+
+class _EnsureFocusVisibleState extends State<EnsureFocusVisible>
+    with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    if (isAndroid) {
+      WidgetsBinding.instance.addObserver(this);
+    }
+  }
+
+  @override
+  void dispose() {
+    if (isAndroid) {
+      WidgetsBinding.instance.removeObserver(this);
+    }
+    super.dispose();
+  }
+
+  @override
+  void didChangeMetrics() {
+    // Called when keyboard appears/disappears or on rotation.
+    // Delay to let the layout settle after the resize.
+    Future.delayed(const Duration(milliseconds: 400), _scrollToFocus);
+  }
+
+  void _scrollToFocus() {
+    final focusedContext = FocusManager.instance.primaryFocus?.context;
+    if (focusedContext == null || !mounted) return;
+    Scrollable.ensureVisible(
+      focusedContext,
+      duration: const Duration(milliseconds: 200),
+      alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!isAndroid) return widget.child;
+    return Focus(
+      onFocusChange: (hasFocus) {
+        if (hasFocus) {
+          Future.delayed(const Duration(milliseconds: 400), _scrollToFocus);
+        }
+      },
+      child: widget.child,
+    );
+  }
+}

--- a/lib/widgets/responsive_dialog.dart
+++ b/lib/widgets/responsive_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2025 Yubico.
+ * Copyright (C) 2022-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import 'package:material_symbols_icons/symbols.dart';
 import '../app/views/keys.dart';
 import '../core/state.dart';
 import '../generated/l10n/app_localizations.dart';
+import 'ensure_focus_visible.dart';
 
 class ResponsiveDialog extends StatefulWidget {
   final Widget? title;
@@ -95,14 +96,62 @@ class _ResponsiveDialogState extends State<ResponsiveDialog> {
       ),
       body: SingleChildScrollView(
         child: SafeArea(
-          child: Container(
-            key: _childKey,
-            child: widget.builder(context, true),
+          child: EnsureFocusVisible(
+            child: Container(
+              key: _childKey,
+              child: widget.builder(context, true),
+            ),
           ),
         ),
       ),
     ),
   );
+
+  Widget _buildCompactDialog(BuildContext context) {
+    return PopScope(
+      canPop: widget.allowCancel,
+      child: Dialog.fullscreen(
+        child: Semantics(
+          scopesRoute: true,
+          namesRoute: true,
+          explicitChildNodes: true,
+          label: _extractTitleText(),
+          child: Scaffold(
+            appBar: AppBar(
+              title: widget.title,
+              actions: widget.actions,
+              leading: IconButton(
+                key: closeButton,
+                tooltip: _getCancelText(context),
+                icon: const Icon(Symbols.close),
+                onPressed: widget.allowCancel
+                    ? () {
+                        widget.onCancel?.call();
+                        Navigator.of(context).pop();
+                      }
+                    : null,
+              ),
+            ),
+            body: Center(
+              child: SingleChildScrollView(
+                child: EnsureFocusVisible(
+                  child: Container(
+                    key: _childKey,
+                    child: widget.builder(context, true),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) {
+          widget.onCancel?.call();
+        }
+      },
+    );
+  }
 
   Widget _buildDialog(BuildContext context) {
     return PopScope(
@@ -125,7 +174,9 @@ class _ResponsiveDialogState extends State<ResponsiveDialog> {
             child: Container(
               key: _childKey,
               child: SingleChildScrollView(
-                child: widget.builder(context, false),
+                child: EnsureFocusVisible(
+                  child: widget.builder(context, false),
+                ),
               ),
             ),
           ),
@@ -166,9 +217,20 @@ class _ResponsiveDialogState extends State<ResponsiveDialog> {
             _hasLostFocus = true;
           }
         },
-        child: constraints.maxWidth < maxWidth
-            ? _buildFullscreen(context)
-            : _buildDialog(context),
+        child: () {
+          if (constraints.maxWidth < maxWidth) {
+            return _buildFullscreen(context);
+          }
+          // On Android in landscape, use compact layout so forms
+          // remain usable when the software keyboard appears.
+          if (isAndroid) {
+            final orientation = MediaQuery.of(context).orientation;
+            if (orientation == Orientation.landscape) {
+              return _buildCompactDialog(context);
+            }
+          }
+          return _buildDialog(context);
+        }(),
       );
     }),
   );


### PR DESCRIPTION
### Summary

Removes the portrait-only lock on Android phones and adds proper landscape support so the app is usable with the software keyboard on phones and small tablets. This also addresses the Android 17 (API 37) behavior where orientation/resizability restrictions are ignored on large screens (sw≥600dp).

### Changes
#### Portrait lock removal
- Removed `portrait_only` boolean resources (`values/bools.xml`, `values-sw600dp/bools.xml`)
- Removed `forcePortraitOrientation()`, `allowAnyOrientation()`, `isPortraitOnly()` from `MainActivity.kt`
- Removed `onMultiWindowModeChanged` override
- Removed `android.hardware.screen.portrait` from `AndroidManifest.xml`

#### Responsive dialog (Android landscape)
- New **compact dialog mode**: when in landscape on Android, `ResponsiveDialog` renders as a fullscreen `Scaffold` with title/actions in the AppBar and scrollable body - instead of a centered `AlertDialog` that gets clipped by the keyboard
- Content is vertically centered when shorter than available space

#### Auto-scroll to focused fields
- New `EnsureFocusVisible` widget (Android-only, no-op on desktop) that listens to `didChangeMetrics` and focus changes, then calls `Scrollable.ensureVisible` to scroll the focused text field above the keyboard
- Applied to `AppPage` content areas and `headerSliver` (search fields)

#### AppPage landscape adaptations (Android-only)
- Sliver title collapses to zero height in landscape to maximize vertical space for content
- Extra bottom padding matching keyboard height added to `CustomScrollView` so short lists can still scroll focused fields into view

### Testing
Tested on:
- Android phone in portrait and landscape
- Android tablet in portrait and landscape
- macOS (no behavioral changes on desktop)