### PR TITLE
Add semantic label to `VisiblityToggleButton`

### DIFF
--- a/lib/widgets/visibility_toggle_button.dart
+++ b/lib/widgets/visibility_toggle_button.dart
@@ -48,8 +48,10 @@ class VisibilityToggleButton extends StatelessWidget {
       label: label,
       onTap: onToggle,
       child: IconButton(
-        icon: Icon(isObscured ? Symbols.visibility : Symbols.visibility_off),
-        isSelected: !isObscured,
+        icon: Icon(
+          isObscured ? Symbols.visibility : Symbols.visibility_off,
+          semanticLabel: label,
+        ),
         onPressed: onToggle,
         tooltip: label,
       ),


### PR DESCRIPTION
This also removes the `isSelected` attribute from `IconButton` since it is not needed. Adding `semanticLabel` makes it work on Win with NVDA