### PR TITLE
fix(android): resolve layout overflows in landscape mode

### DIFF
--- a/lib/android/overlay/nfc/nfc_event_notifier.dart
+++ b/lib/android/overlay/nfc/nfc_event_notifier.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Yubico.
+ * Copyright (C) 2024-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,11 +106,28 @@ class _NfcEventNotifierListener {
         context: context,
         isDismissible: isDismissible,
         enableDrag: isDismissible,
+        // Use isScrollControlled to remove the default 9/16 landscape height
+        // cap. The sheet still sizes to its content (mainAxisSize: min).
+        isScrollControlled: true,
         routeSettings: RouteSettings(name: 'android_nfc_activity_overlay'),
         builder: (BuildContext context) {
-          return PopScope(
+          // Read MediaQuery inside the builder so constraints update on
+          // orientation changes while the sheet is visible.
+          final mediaQuery = MediaQuery.of(context);
+          final isLandscape = mediaQuery.orientation == Orientation.landscape;
+          final sheet = PopScope(
             canPop: isDismissible,
             child: const NfcOverlayWidget(),
+          );
+          if (!isLandscape) return sheet;
+          // In landscape, constrain the width to 50 % of the screen
+          // (clamped to a sensible range) so the sheet doesn't span the
+          // full width.
+          return ConstrainedBox(
+            constraints: BoxConstraints(
+              maxWidth: (mediaQuery.size.width * 0.5).clamp(280.0, 480.0),
+            ),
+            child: sheet,
           );
         },
       );

--- a/lib/app/views/app_page.dart
+++ b/lib/app/views/app_page.dart
@@ -478,6 +478,11 @@ class _AppPageState extends ConsumerState<AppPage> {
                   context,
                 ).copyWith(scrollbars: false),
                 child: SingleChildScrollView(
+                  padding: isAndroid
+                      ? EdgeInsets.only(
+                          bottom: MediaQuery.of(context).viewInsets.bottom,
+                        )
+                      : null,
                   physics: isAndroid
                       ? const ClampingScrollPhysics(
                           parent: AlwaysScrollableScrollPhysics(),
@@ -584,6 +589,9 @@ class _AppPageState extends ConsumerState<AppPage> {
     }
 
     return SingleChildScrollView(
+      padding: isAndroid
+          ? EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom)
+          : null,
       physics: isAndroid
           ? const ClampingScrollPhysics(parent: AlwaysScrollableScrollPhysics())
           : null,
@@ -778,6 +786,10 @@ class _AppPageState extends ConsumerState<AppPage> {
           policy: OrderedTraversalPolicy(),
           child: Scaffold(
             key: scaffoldGlobalKey,
+            // On Android, prevent the outer Scaffold from resizing for the
+            // keyboard. The navigation rail must keep its full height; inner
+            // content (dialogs, pages) handles keyboard insets on its own.
+            resizeToAvoidBottomInset: !isAndroid,
             appBar: AppBar(
               bottom: PreferredSize(
                 preferredSize: const Size.fromHeight(1.0),

--- a/lib/app/views/navigation.dart
+++ b/lib/app/views/navigation.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2025 Yubico.
+ * Copyright (C) 2023-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import 'package:vector_graphics/vector_graphics.dart';
 import 'package:vector_graphics_compiler/vector_graphics_compiler.dart'
     show encodeSvg;
 
+import '../../core/state.dart';
 import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/focus_border.dart';
 import '../models.dart';
@@ -233,7 +234,7 @@ class MoreItem extends ConsumerWidget {
             (e) => ConstrainedBox(
               constraints: BoxConstraints(minWidth: 150),
               child: MenuItemButton(
-                leadingIcon: Icon(e._icon),
+                leadingIcon: e.buildIcon(selected: false),
                 onPressed:
                     data != null &&
                         e.getAvailability(data) == Availability.enabled
@@ -405,7 +406,9 @@ class NavigationContent extends ConsumerWidget {
             child: LayoutBuilder(
               builder: (context, constraints) {
                 final totalHeight = constraints.maxHeight;
-                final itemHeight = 53;
+                // On Android landscape, use actual collapsed item height
+                // to keep the rail tight and avoid overflow.
+                final itemHeight = isAndroid && !extended ? 61 : 53;
 
                 // Available height for the app list
                 final appListHeight = totalHeight - itemHeight;

--- a/lib/widgets/ensure_focus_visible.dart
+++ b/lib/widgets/ensure_focus_visible.dart
@@ -59,11 +59,44 @@ class _EnsureFocusVisibleState extends State<EnsureFocusVisible>
   void _scrollToFocus() {
     final focusedContext = FocusManager.instance.primaryFocus?.context;
     if (focusedContext == null || !mounted) return;
-    Scrollable.ensureVisible(
-      focusedContext,
-      duration: const Duration(milliseconds: 200),
-      alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
-    );
+
+    final keyboardHeight = MediaQuery.of(context).viewInsets.bottom;
+    if (keyboardHeight > 0) {
+      // When resizeToAvoidBottomInset is false, the viewport extends behind
+      // the keyboard. ensureVisible thinks the widget is already visible.
+      // Manually check and scroll so the widget is above the keyboard.
+      final focusedObject = focusedContext.findRenderObject();
+      if (focusedObject is RenderBox && focusedObject.attached) {
+        final offset = focusedObject.localToGlobal(Offset.zero);
+        final widgetBottom = offset.dy + focusedObject.size.height;
+        final screenHeight = MediaQuery.of(context).size.height;
+        final visibleBottom = screenHeight - keyboardHeight;
+
+        if (widgetBottom > visibleBottom - 16) {
+          // Widget is behind or too close to the keyboard — scroll it up.
+          final scrollable = Scrollable.maybeOf(focusedContext);
+          if (scrollable != null) {
+            final position = scrollable.position;
+            final overlap = widgetBottom - visibleBottom + 16;
+            final target = (position.pixels + overlap).clamp(
+              position.minScrollExtent,
+              position.maxScrollExtent,
+            );
+            position.animateTo(
+              target,
+              duration: const Duration(milliseconds: 200),
+              curve: Curves.easeInOut,
+            );
+          }
+        }
+      }
+    } else {
+      Scrollable.ensureVisible(
+        focusedContext,
+        duration: const Duration(milliseconds: 200),
+        alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
+      );
+    }
   }
 
   @override

--- a/lib/widgets/responsive_dialog.dart
+++ b/lib/widgets/responsive_dialog.dart
@@ -116,24 +116,24 @@ class _ResponsiveDialogState extends State<ResponsiveDialog> {
           namesRoute: true,
           explicitChildNodes: true,
           label: _extractTitleText(),
-          child: Scaffold(
-            appBar: AppBar(
-              title: widget.title,
-              actions: widget.actions,
-              leading: IconButton(
-                key: closeButton,
-                tooltip: _getCancelText(context),
-                icon: const Icon(Symbols.close),
-                onPressed: widget.allowCancel
-                    ? () {
-                        widget.onCancel?.call();
-                        Navigator.of(context).pop();
-                      }
-                    : null,
+          child: SafeArea(
+            child: Scaffold(
+              appBar: AppBar(
+                title: widget.title,
+                actions: widget.actions,
+                leading: IconButton(
+                  key: closeButton,
+                  tooltip: _getCancelText(context),
+                  icon: const Icon(Symbols.close),
+                  onPressed: widget.allowCancel
+                      ? () {
+                          widget.onCancel?.call();
+                          Navigator.of(context).pop();
+                        }
+                      : null,
+                ),
               ),
-            ),
-            body: Center(
-              child: SingleChildScrollView(
+              body: SingleChildScrollView(
                 child: EnsureFocusVisible(
                   child: Container(
                     key: _childKey,


### PR DESCRIPTION
## Summary

Fixes multiple RenderFlex overflow errors on Android in landscape
orientation across the navigation rail, NFC overlay bottom sheet,
and responsive dialogs. All changes are gated behind `isAndroid`
checks so desktop platforms are unaffected.

## Changes

- Disable `resizeToAvoidBottomInset` on the outer Scaffold on
  Android so the navigation rail is not shrunk by the keyboard
- Add bottom padding equal to keyboard height on all three
  scroll view paths so content can scroll above the keyboard
- Update `EnsureFocusVisible` to manually scroll focused widgets
  above the keyboard when the viewport doesn't resize
- Use `isScrollControlled: true` on the NFC bottom sheet to
  remove the default 9/16 landscape height cap, and constrain
  the sheet width to 50% of screen in landscape
- Use correct collapsed item height (61px) on Android for the
  navigation rail's visible-apps calculation
- Add `SafeArea` and remove vertical centering in the compact
  responsive dialog layout used on Android landscape
- Use `buildIcon(selected: false)` in the "More" overflow menu
  so the passkey icon renders with the outline variant