### PR TITLE
fix(android): handle NFC HAL crash on startup

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
@@ -82,6 +82,7 @@ import java.security.Security
 import java.util.concurrent.Executors
 import javax.crypto.Mac
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -100,6 +101,7 @@ class MainActivity : FlutterFragmentActivity() {
     private val nfcConfiguration = NfcConfiguration().timeout(5000)
 
     private var hasNfc: Boolean = false
+    private var nfcRetryJob: Job? = null
 
     private lateinit var yubikit: YubiKitManager
 
@@ -170,11 +172,11 @@ class MainActivity : FlutterFragmentActivity() {
             hasNfc = true
         } catch (_: NfcNotAvailable) {
             hasNfc = false
-        } catch (e: Exception) {
-            logger.error("Start NFC discovery failed (attempt {}): {}", retryCount + 1, e.message)
+        } catch (e: RuntimeException) {
+            logger.error("Start NFC discovery failed (attempt {})", retryCount + 1, e)
             hasNfc = false
             if (retryCount < NFC_DISCOVERY_MAX_RETRIES) {
-                lifecycleScope.launch(Dispatchers.Main) {
+                nfcRetryJob = lifecycleScope.launch(Dispatchers.Main) {
                     delay(NFC_DISCOVERY_RETRY_DELAY_MS)
                     startNfcDiscovery(retryCount + 1)
                 }
@@ -188,6 +190,8 @@ class MainActivity : FlutterFragmentActivity() {
     }
 
     private fun stopNfcDiscovery() {
+        nfcRetryJob?.cancel()
+        nfcRetryJob = null
         if (hasNfc) {
             yubikit.stopNfcDiscovery(this)
             logger.debug("Stopped nfc discovery")

--- a/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
@@ -82,6 +82,7 @@ import java.security.Security
 import java.util.concurrent.Executors
 import javax.crypto.Mac
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.bouncycastle.jce.provider.BouncyCastleProvider
@@ -154,20 +155,36 @@ class MainActivity : FlutterFragmentActivity() {
         setIntent(intent)
     }
 
-    private fun startNfcDiscovery() = try {
-        logger.debug("Starting nfc discovery")
-        yubikit.startNfcDiscovery(
-            nfcConfiguration.disableNfcDiscoverySound(appPreferences.silenceNfcSounds),
-            this
-        ) { nfcYubiKeyDevice ->
-            if (!deviceManager.isUsbKeyConnected()) {
-                launchProcessYubiKey(nfcYubiKeyDevice)
+    private fun startNfcDiscovery(retryCount: Int = 0) {
+        try {
+            logger.debug("Starting nfc discovery")
+            yubikit.startNfcDiscovery(
+                nfcConfiguration.disableNfcDiscoverySound(appPreferences.silenceNfcSounds),
+                this
+            ) { nfcYubiKeyDevice ->
+                if (!deviceManager.isUsbKeyConnected()) {
+                    launchProcessYubiKey(nfcYubiKeyDevice)
+                }
+            }
+
+            hasNfc = true
+        } catch (_: NfcNotAvailable) {
+            hasNfc = false
+        } catch (e: Exception) {
+            logger.error("Start NFC discovery failed (attempt {}): {}", retryCount + 1, e.message)
+            hasNfc = false
+            if (retryCount < NFC_DISCOVERY_MAX_RETRIES) {
+                lifecycleScope.launch(Dispatchers.Main) {
+                    delay(NFC_DISCOVERY_RETRY_DELAY_MS)
+                    startNfcDiscovery(retryCount + 1)
+                }
+            } else {
+                logger.error(
+                    "Start NFC discovery failed after {} attempts, giving up",
+                    NFC_DISCOVERY_MAX_RETRIES + 1
+                )
             }
         }
-
-        hasNfc = true
-    } catch (_: NfcNotAvailable) {
-        hasNfc = false
     }
 
     private fun stopNfcDiscovery() {
@@ -629,6 +646,8 @@ class MainActivity : FlutterFragmentActivity() {
     companion object {
         const val YUBICO_VENDOR_ID = 4176
         const val FLAG_SECURE = WindowManager.LayoutParams.FLAG_SECURE
+        private const val NFC_DISCOVERY_MAX_RETRIES = 3
+        private const val NFC_DISCOVERY_RETRY_DELAY_MS = 2000L
         val supportsScp11b = try {
             Mac.getInstance("AESCMAC")
             true


### PR DESCRIPTION
## Summary

Prevents app crash when the NFC HAL service dies during startup (observed on OnePlus 7 Pro with LineageOS). Adds retry logic to recover NFC discovery after transient failures.

## Changes

- Catch RuntimeException from NfcAdapter.enableReaderMode when the NFC service is dead (DeadObjectException)
- Retry NFC discovery up to 3 times with 2-second delay between attempts, allowing the HAL to restart
- Set hasNfc = false on failure to prevent stopNfcDiscovery from accessing uninitialized YubiKit state
- Convert startNfcDiscovery from expression body to block body to support recursive retry calls

Fixes #2167