### PR TITLE
fix(android): split NDEF and App Link aliases

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -83,6 +83,8 @@
             android:theme="@style/NdefActivityTheme">
         </activity>
 
+        <!-- NFC tag dispatch on Android 15 and below, and as a fallback for
+             builds whose App Links are not verified. -->
         <activity-alias
             android:name=".AliasNdefActivity"
             android:exported="true"
@@ -91,22 +93,35 @@
             android:theme="@style/NdefActivityTheme"
             android:targetActivity=".NdefActivity">
 
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-                <data
-                    android:host="my.yubico.com"
-                    android:scheme="https" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-            </intent-filter>
-
             <intent-filter>
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data
                     android:host="my.yubico.com"
                     android:scheme="https" />
+            </intent-filter>
 
+        </activity-alias>
+
+        <!-- App Link handler — required by Android 16+ for NFC URL dispatch.
+             Verified via Digital Asset Links (assetlinks.json). The app does
+             not handle browser visits to my.yubico.com beyond what Android 16
+             requires for the NFC code path. -->
+        <activity-alias
+            android:name=".AliasNdefAppLinkActivity"
+            android:exported="true"
+            android:enabled="true"
+            android:launchMode="singleTop"
+            android:theme="@style/NdefActivityTheme"
+            android:targetActivity=".NdefActivity">
+
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:host="my.yubico.com"
+                    android:scheme="https" />
             </intent-filter>
 
         </activity-alias>

--- a/android/app/src/main/kotlin/com/yubico/authenticator/ActivityUtil.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/ActivityUtil.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,36 +62,42 @@ class ActivityUtil(private val activity: Activity) {
     /**
      * The system will start the app when an NDEF tag with recognized URI is discovered.
      *
-     * Calling this method will enable <code>AliasNdefActivity</code> alias and the intent-filter
-     * for android.nfc.action.NDEF_DISCOVERED will be active. This is the default behavior as
-     * defined in the AndroidManifest.xml.
+     * Calling this method will enable both <code>AliasNdefActivity</code> (handling
+     * android.nfc.action.NDEF_DISCOVERED on Android 15 and below, and as a fallback on builds
+     * whose App Links cannot be verified) and <code>AliasNdefAppLinkActivity</code> (handling
+     * the Android 16+ android.intent.action.VIEW dispatch for verified App Links). This is the
+     * default behavior as defined in the AndroidManifest.xml.
      *
-     * For list of discoverable URIs see the alias definition in AndroidManifest.xml.
+     * For list of discoverable URIs see the alias definitions in AndroidManifest.xml.
      *
      * @see <a href="https://developer.android.com/guide/topics/manifest/activity-alias-element">Activity Alias in Android SDK documentation</a>
      */
     fun enableAppNfcDiscovery() {
-        setState(
-            NDEF_ACTIVITY_ALIAS,
-            PackageManager.COMPONENT_ENABLED_STATE_DEFAULT
+        setState(NDEF_ACTIVITY_ALIAS, PackageManager.COMPONENT_ENABLED_STATE_DEFAULT)
+        setState(NDEF_APP_LINK_ACTIVITY_ALIAS, PackageManager.COMPONENT_ENABLED_STATE_DEFAULT)
+        logger.debug(
+            "Enabled NFC discovery by setting state of $NDEF_ACTIVITY_ALIAS and $NDEF_APP_LINK_ACTIVITY_ALIAS to DEFAULT"
         )
-        logger.debug("Enabled NFC discovery by setting state of $NDEF_ACTIVITY_ALIAS to DEFAULT")
     }
 
     /**
      * The system will ignore the app when NDEF tags are discovered.
      *
-     * Calling this method will disable <code>AliasNdefActivity</code> alias and there will be no
-     * active intent-filter for android.nfc.action.NDEF_DISCOVERED.
+     * Calling this method will disable both <code>AliasNdefActivity</code> and
+     * <code>AliasNdefAppLinkActivity</code>, removing them from the system NFC resolver so the
+     * app is neither offered as a handler nor launched on tap. <code>DISABLED</code> (rather
+     * than <code>DEFAULT</code>) is required because the manifest declares both aliases as
+     * <code>android:enabled="true"</code>; <code>DEFAULT</code> would leave them visible in the
+     * NFC chooser.
      *
      * @see <a href="https://developer.android.com/guide/topics/manifest/activity-alias-element">Activity Alias in Android SDK documentation</a>
      */
     fun disableAppNfcDiscovery() {
-        setState(
-            NDEF_ACTIVITY_ALIAS,
-            PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+        setState(NDEF_ACTIVITY_ALIAS, PackageManager.COMPONENT_ENABLED_STATE_DISABLED)
+        setState(NDEF_APP_LINK_ACTIVITY_ALIAS, PackageManager.COMPONENT_ENABLED_STATE_DISABLED)
+        logger.debug(
+            "Disabled NFC discovery by setting state of $NDEF_ACTIVITY_ALIAS and $NDEF_APP_LINK_ACTIVITY_ALIAS to DISABLED"
         )
-        logger.debug("Disabled NFC discovery by setting state of $NDEF_ACTIVITY_ALIAS to DISABLED")
     }
 
     private fun setState(aliasName: String, enabledState: Int) {
@@ -107,6 +113,7 @@ class ActivityUtil(private val activity: Activity) {
 
     companion object {
         const val NDEF_ACTIVITY_ALIAS = "AliasNdefActivity"
+        const val NDEF_APP_LINK_ACTIVITY_ALIAS = "AliasNdefAppLinkActivity"
         const val MAIN_ACTIVITY_ALIAS = "AliasMainActivity"
     }
 }


### PR DESCRIPTION
## Summary

Splits `AliasNdefActivity` so that `NDEF_DISCOVERED` and the `ACTION_VIEW` + `autoVerify` App Link filter live on separate `activity-alias` entries. This is a structural cleanup that decouples NFC tag dispatch from App Link verification state.

This change is unlikely to be a user-visible fix on its own. The reported regression on Android 16 is rooted in a platform behavior change: from Android 16, URL tags are dispatched via standard `ACTION_VIEW` and only verified App Link handlers receive them - `NDEF_DISCOVERED` is no longer tried for URL tags regardless of how the manifest is structured. For builds whose App Link is not verified (sideloads, builds signed with non-Play keys, distributions on systems where DAL verification doesn't run), the user-visible workaround is to associate the domain manually one time via Settings → Apps → Yubico Authenticator → Open by default → add `my.yubico.com`.

The split may still help on Android 12–15 with unverified App Links, where the reporter's "Safer Intents poisoning" theory could apply (combined alias treated as fully unverified, blocking NDEF dispatch as well). That path could not be tested locally.

## Changes

- Split `AliasNdefActivity` into two aliases targeting the same `NdefActivity`:
  - `AliasNdefActivity` keeps only `android.nfc.action.NDEF_DISCOVERED` (Android 15 and below, plus the fallback path for builds whose App Links are not verified).
  - New `AliasNdefAppLinkActivity` carries `android.intent.action.VIEW` + `android:autoVerify="true"` + `BROWSABLE` (required by Android 16+  for NFC URL dispatch).
- `ActivityUtil.enableAppNfcDiscovery()` / `disableAppNfcDiscovery()` now toggle both aliases together so the "Launch on NFC tap" preference applies consistently across Android versions.
- Kept `COMPONENT_ENABLED_STATE_DISABLED` for the off path - `DEFAULT` would leave the aliases visible in the system NFC chooser when the preference is off.

Refs #2178