### PR TITLE
android: prompt for my.yubico.com link association

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/DomainVerificationHelper.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/DomainVerificationHelper.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.authenticator
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.verify.domain.DomainVerificationManager
+import android.content.pm.verify.domain.DomainVerificationUserState
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import org.slf4j.LoggerFactory
+
+/**
+ * Helper for inspecting and managing the system-level "Open by default" status
+ * of the my.yubico.com domain.
+ *
+ * On Android 16 (API 36), NFC taps on a YubiKey no longer broadcast
+ * NDEF_DISCOVERED but launch the my.yubico.com URL via ACTION_VIEW. The app is
+ * registered to handle that URL but, unless Digital Asset Links auto-verifies
+ * the association or the user manually opted in via Settings → Apps → Yubico
+ * Authenticator → Open by default, ACTION_VIEW falls back to a browser. This
+ * helper lets the app detect that situation and deep-link the user to the
+ * relevant settings page.
+ *
+ * The DomainVerificationManager API is available from Android 12 (API 31), but
+ * the underlying problem only exists on Android 16+: on earlier releases NFC
+ * taps still arrive via NDEF_DISCOVERED regardless of link verification state.
+ * Therefore [getStatus] returns [STATUS_UNSUPPORTED] below API 36 to avoid
+ * nagging users on OS versions that aren't affected.
+ */
+object DomainVerificationHelper {
+    private const val YUBICO_HOST = "my.yubico.com"
+
+    // Android 16 / Baklava. Hardcoded so this compiles regardless of which
+    // version constants are present in the configured compileSdk.
+    private const val ANDROID_16 = 36
+
+    /** API not available, or running on an OS version unaffected by the issue. */
+    const val STATUS_UNSUPPORTED = "unsupported"
+
+    /** Domain is auto-verified via Digital Asset Links — no action needed. */
+    const val STATUS_VERIFIED = "verified"
+
+    /** User has explicitly opted the app in for the domain — no action needed. */
+    const val STATUS_SELECTED = "selected"
+
+    /** No association — ACTION_VIEW will fall back to a browser. */
+    const val STATUS_NONE = "none"
+
+    private val logger = LoggerFactory.getLogger(DomainVerificationHelper::class.java)
+
+    fun getStatus(context: Context): String {
+        // Only Android 16 routes NFC YubiKey taps through ACTION_VIEW; older
+        // releases still deliver NDEF_DISCOVERED, so the association state
+        // is irrelevant for tap-to-launch there.
+        if (Build.VERSION.SDK_INT < ANDROID_16) {
+            return STATUS_UNSUPPORTED
+        }
+        return try {
+            val manager = context.getSystemService(DomainVerificationManager::class.java)
+                ?: return STATUS_UNSUPPORTED
+            val userState = manager.getDomainVerificationUserState(context.packageName)
+                ?: return STATUS_UNSUPPORTED
+            // If the user disabled "Open supported links" globally for the
+            // app, ACTION_VIEW won't be routed here even when individual
+            // hosts are verified or selected. Treat that as not associated.
+            if (!userState.isLinkHandlingAllowed) {
+                return STATUS_NONE
+            }
+            when (userState.hostToStateMap[YUBICO_HOST]) {
+                DomainVerificationUserState.DOMAIN_STATE_VERIFIED -> STATUS_VERIFIED
+                DomainVerificationUserState.DOMAIN_STATE_SELECTED -> STATUS_SELECTED
+                DomainVerificationUserState.DOMAIN_STATE_NONE -> STATUS_NONE
+                // Host not registered for this app.
+                null -> STATUS_UNSUPPORTED
+                else -> STATUS_NONE
+            }
+        } catch (e: Exception) {
+            logger.warn("Failed to query domain verification state", e)
+            STATUS_UNSUPPORTED
+        }
+    }
+
+    /**
+     * Opens the system "Open by default" page for this app. Available from
+     * Android 12 (API 31), but only invoked from the Android 16+ flow.
+     * Returns true if a settings activity was started.
+     */
+    fun openSettings(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            return false
+        }
+        val uri = Uri.fromParts("package", context.packageName, null)
+        val flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        // ACTION_APP_OPEN_BY_DEFAULT_SETTINGS deep-links to the per-app
+        // "Open by default" page on Android 12+, where the user can toggle
+        // "Open supported links" and review my.yubico.com.
+        val direct = Intent(Settings.ACTION_APP_OPEN_BY_DEFAULT_SETTINGS, uri)
+            .addFlags(flags)
+        if (direct.resolveActivity(context.packageManager) != null) {
+            context.startActivity(direct)
+            return true
+        }
+        val fallback = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, uri)
+            .addFlags(flags)
+        if (fallback.resolveActivity(context.packageManager) != null) {
+            context.startActivity(fallback)
+            return true
+        }
+        logger.warn("No settings activity available for domain verification")
+        return false
+    }
+}

--- a/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
@@ -753,6 +753,14 @@ class MainActivity : FlutterFragmentActivity() {
                         result.success(true)
                     }
 
+                    "getDomainVerificationStatus" -> result.success(
+                        DomainVerificationHelper.getStatus(this@MainActivity)
+                    )
+
+                    "openDomainVerificationSettings" -> result.success(
+                        DomainVerificationHelper.openSettings(this@MainActivity)
+                    )
+
                     else -> logger.warn("Unknown app method: {}", methodCall.method)
                 }
             }

--- a/lib/android/app_methods.dart
+++ b/lib/android/app_methods.dart
@@ -51,6 +51,47 @@ Future<void> openNfcSettings() async {
   await appMethodsChannel.invokeMethod('openNfcSettings');
 }
 
+/// System-level association status of the my.yubico.com domain with this app.
+///
+/// On Android 16 (API 36+), NFC taps on a YubiKey route through ACTION_VIEW
+/// for https://my.yubico.com instead of NDEF_DISCOVERED. Unless the domain is
+/// auto-verified via Digital Asset Links or the user enabled "Open by default"
+/// for the app, ACTION_VIEW falls back to a browser.
+enum DomainVerificationStatus {
+  /// Pre-Android 12, or API not available.
+  unsupported,
+
+  /// Domain is auto-verified — no user action required.
+  verified,
+
+  /// User has opted the app in — no user action required.
+  selected,
+
+  /// No association — the user should be prompted to enable it.
+  none;
+
+  bool get isAssociated => this == verified || this == selected;
+}
+
+Future<DomainVerificationStatus> getDomainVerificationStatus() async {
+  final value = await appMethodsChannel.invokeMethod<String>(
+    'getDomainVerificationStatus',
+  );
+  return switch (value) {
+    'verified' => DomainVerificationStatus.verified,
+    'selected' => DomainVerificationStatus.selected,
+    'none' => DomainVerificationStatus.none,
+    _ => DomainVerificationStatus.unsupported,
+  };
+}
+
+Future<bool> openDomainVerificationSettings() async {
+  final result = await appMethodsChannel.invokeMethod<bool>(
+    'openDomainVerificationSettings',
+  );
+  return result ?? false;
+}
+
 Future<int> getAndroidSdkVersion() async {
   return await appMethodsChannel.invokeMethod('getAndroidSdkVersion');
 }

--- a/lib/android/init.dart
+++ b/lib/android/init.dart
@@ -39,6 +39,7 @@ import 'app_methods.dart';
 import 'fido/state.dart';
 import 'logger.dart';
 import 'management/state.dart';
+import 'models.dart';
 import 'oath/otp_auth_link_handler.dart';
 import 'oath/state.dart';
 import 'overlay/nfc/nfc_event_notifier.dart';
@@ -46,6 +47,7 @@ import 'overlay/nfc/nfc_overlay.dart';
 import 'piv/state.dart';
 import 'qr_scanner/qr_scanner_provider.dart';
 import 'state.dart';
+import 'views/domain_association_prompt.dart';
 import 'window_state_provider.dart';
 
 Future<Widget> initialize({Level? level}) async {
@@ -146,6 +148,21 @@ Future<Widget> initialize({Level? level}) async {
             setupOtpAuthLinkHandler(context);
 
             setupAppMethodsChannel(ref);
+
+            // Once per install/update, prompt the user to associate
+            // my.yubico.com with the app if they have a launch action
+            // enabled. Required for NFC tap to launch the app on
+            // Android 16 where NDEF_DISCOVERED is no longer delivered.
+            final tapAction = ref.read(androidNfcTapActionProvider);
+            if (tapAction == NfcTapAction.launch ||
+                tapAction == NfcTapAction.launchAndCopy) {
+              final prefs = ref.read(prefProvider);
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                if (context.mounted) {
+                  maybePromptDomainAssociationOnStartup(context, prefs);
+                }
+              });
+            }
 
             return const MainPage();
           },

--- a/lib/android/views/domain_association_prompt.dart
+++ b/lib/android/views/domain_association_prompt.dart
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../generated/l10n/app_localizations.dart';
+import '../../version.dart' as app_version;
+import '../../widgets/basic_dialog.dart';
+import '../app_methods.dart';
+
+/// SharedPreferences key tracking the build number for which the user has
+/// already seen the my.yubico.com association prompt at startup. The prompt
+/// is re-shown after install/update if the domain still isn't associated.
+const _kPromptedBuildKey = 'androidDomainPromptedBuild';
+
+Future<void> _showDialog(BuildContext context) async {
+  final accepted = await showDialog<bool>(
+    context: context,
+    builder: (context) {
+      final l10n = AppLocalizations.of(context);
+      return BasicDialog(
+        icon: const Icon(Symbols.link),
+        title: Text(l10n.s_link_my_yubico),
+        content: Text(l10n.p_link_my_yubico_desc),
+        onCancel: () {},
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(l10n.s_open_settings),
+          ),
+        ],
+      );
+    },
+  );
+  if (accepted == true) {
+    await openDomainVerificationSettings();
+  }
+}
+
+/// Shows an explanation dialog and offers to deep-link the user to the
+/// system "Open by default" settings if my.yubico.com is not associated
+/// with this app. No-op when the domain is already associated, when the
+/// API is unavailable, or when the widget is no longer mounted.
+Future<void> promptDomainAssociation(BuildContext context) async {
+  final status = await getDomainVerificationStatus();
+  if (status != DomainVerificationStatus.none) {
+    return;
+  }
+  if (!context.mounted) {
+    return;
+  }
+  await _showDialog(context);
+}
+
+/// Like [promptDomainAssociation] but only shows the dialog once per app
+/// build. Used at startup so the user is reminded after install/update
+/// without being nagged on every launch.
+Future<void> maybePromptDomainAssociationOnStartup(
+  BuildContext context,
+  SharedPreferences prefs,
+) async {
+  if (prefs.getInt(_kPromptedBuildKey) == app_version.build) {
+    return;
+  }
+  final status = await getDomainVerificationStatus();
+  if (status == DomainVerificationStatus.unsupported) {
+    // No deep-linkable settings page on this OS version.
+    return;
+  }
+  // Record the prompt attempt regardless of outcome so we don't keep
+  // showing it on every launch when the user dismisses it.
+  await prefs.setInt(_kPromptedBuildKey, app_version.build);
+  if (status != DomainVerificationStatus.none) {
+    return;
+  }
+  if (!context.mounted) {
+    return;
+  }
+  await _showDialog(context);
+}

--- a/lib/app/views/settings_page.dart
+++ b/lib/app/views/settings_page.dart
@@ -26,6 +26,7 @@ import 'package:material_symbols_icons/symbols.dart';
 import '../../android/app_methods.dart';
 import '../../android/models.dart';
 import '../../android/state.dart';
+import '../../android/views/domain_association_prompt.dart';
 import '../../core/models.dart';
 import '../../core/state.dart';
 import '../../desktop/state.dart';
@@ -927,6 +928,14 @@ class _NfcTapActionView extends ConsumerWidget {
       onChanged: (mode) {
         if (mode != null) {
           ref.read(androidNfcTapActionProvider.notifier).setTapAction(mode);
+          // On Android 16, NFC taps go through ACTION_VIEW for
+          // my.yubico.com instead of NDEF_DISCOVERED. Selecting a launch
+          // action is useless if the domain isn't associated with the
+          // app, so prompt the user to enable it.
+          if (mode == NfcTapAction.launch ||
+              mode == NfcTapAction.launchAndCopy) {
+            promptDomainAssociation(context);
+          }
         }
       },
       child: Column(

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -1087,6 +1087,8 @@
     "l_launch_app_on_usb_off": "Ostatní aplikace mohou používat YubiKey přes USB",
     "s_allow_screenshots": "Povolit snímky obrazovky",
     "l_allow_screenshots_desc": "Povolit pořizovat snímky obrazovky",
+    "s_link_my_yubico": null,
+    "p_link_my_yubico_desc": null,
     "@_nfc": {},
 
     "s_nfc_ready_to_scan": "Připraveno ke skenování",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1087,6 +1087,8 @@
     "l_launch_app_on_usb_off": "Andere Anwendungen können den YubiKey über USB nutzen",
     "s_allow_screenshots": "Bildschirmfotos erlauben",
     "l_allow_screenshots_desc": "Erlaube anderen Apps Screenshots zu erstellen",
+    "s_link_my_yubico": null,
+    "p_link_my_yubico_desc": null,
     "@_nfc": {},
 
     "s_nfc_ready_to_scan": "Bereit zum Scannen",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -1087,6 +1087,8 @@
     "l_launch_app_on_usb_off": "Άλλες εφαρμογές μπορούν να χρησιμοποιούν το YubiKey μέσω USB",
     "s_allow_screenshots": "Να επιτρέπονται τα στιγμιότυπα οθόνης",
     "l_allow_screenshots_desc": "Να επιτρέπεται η λήψη στιγμιοτύπων από άλλες εφαρμογές",
+    "s_link_my_yubico": null,
+    "p_link_my_yubico_desc": null,
     "@_nfc": {},
 
     "s_nfc_ready_to_scan": "Έτοιμο για σάρωση",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1087,6 +1087,8 @@
     "l_launch_app_on_usb_off": "Other apps can use the YubiKey over USB",
     "s_allow_screenshots": "Allow screenshots",
     "l_allow_screenshots_desc": "Allow other apps to take screenshots",
+    "s_link_my_yubico": "Open NFC links",
+    "p_link_my_yubico_desc": "On Android 16, NFC taps on a YubiKey open my.yubico.com links instead of using the legacy NDEF event. To launch Yubico Authenticator on tap, allow this app to handle my.yubico.com links in the system \"Open by default\" settings.",
     "@_nfc": {},
 
     "s_nfc_ready_to_scan": "Ready to scan",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1087,6 +1087,8 @@
     "l_launch_app_on_usb_off": "Otras aplicaciones pueden utilizar la YubiKey a través de USB",
     "s_allow_screenshots": "Permitir capturas de pantalla",
     "l_allow_screenshots_desc": null,
+    "s_link_my_yubico": null,
+    "p_link_my_yubico_desc": null,
     "@_nfc": {},
 
     "s_nfc_ready_to_scan": "Listo para escanear",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1087,6 +1087,8 @@
     "l_launch_app_on_usb_off": "D'autres applications peuvent utiliser la YubiKey en USB",
     "s_allow_screenshots": "Autoriser captures d'écran",
     "l_allow_screenshots_desc": "Autoriser d'autres applications à prendre des captures d'écran",
+    "s_link_my_yubico": null,
+    "p_link_my_yubico_desc": null,
     "@_nfc": {},
 
     "s_nfc_ready_to_scan": "Prêt à scanner",

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -1087,6 +1087,8 @@
     "l_launch_app_on_usb_off": "Más alkalmazások használhatják a YubiKey-t USB-n keresztül",
     "s_allow_screenshots": "Képernyőmentés engedélyezése",
     "l_allow_screenshots_desc": "Más alkalmazások készíthetnek képernyőmentést",
+    "s_link_my_yubico": null,
+    "p_link_my_yubico_desc": null,
     "@_nfc": {},
 
     "s_nfc_ready_to_scan": "Szkennelésre kész",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1087,6 +1087,8 @@
     "l_launch_app_on_usb_off": "Altre applicazioni possono utilizzare la YubiKey tramite USB",
     "s_allow_screenshots": "Consenti screenshot",
     "l_allow_screenshots_desc": "Consenti ad altre app di acquisire screenshot",
+    "s_link_my_yubico": null,
+    "p_link_my_yubico_desc": null,
     "@_nfc": {},
 
     "s_nfc_ready_to_scan": "Pronto per la scansione",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1087,6 +1087,8 @@
     "l_launch_app_on_usb_off": "他のアプリは USB 経由で YubiKey を使用できます",
     "s_allow_screenshots": "スクリーンショットを許可する",
     "l_allow_screenshots_desc": "他のアプリにスクリーンショットの撮影を許可します",
+    "s_link_my_yubico": null,
+    "p_link_my_yubico_desc": null,
     "@_nfc": {},
 
     "s_nfc_ready_to_scan": "スキャンの準備完了",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -1087,6 +1087,8 @@
     "l_launch_app_on_usb_off": "Andere apps mogen de YubiKey via USB gebruiken",
     "s_allow_screenshots": "Schermopnames toestaan",
     "l_allow_screenshots_desc": "Andere apps toestaan om schermafbeeldingen te maken",
+    "s_link_my_yubico": null,
+    "p_link_my_yubico_desc": null,
     "@_nfc": {},
 
     "s_nfc_ready_to_scan": "Klaar om te scannen",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -1087,6 +1087,8 @@
     "l_launch_app_on_usb_off": "Inne aplikacje mogą korzystać z klucza YubiKey przez USB",
     "s_allow_screenshots": "Zezwalaj na zrzuty ekranu",
     "l_allow_screenshots_desc": "Zezwalaj innym aplikacjom na wykonywanie zrzutów ekranu",
+    "s_link_my_yubico": null,
+    "p_link_my_yubico_desc": null,
     "@_nfc": {},
 
     "s_nfc_ready_to_scan": "Gotowy do skanowania",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1087,6 +1087,8 @@
     "l_launch_app_on_usb_off": "Outros aplicativos podem usar o YubiKey via USB",
     "s_allow_screenshots": "Permitir capturas de tela",
     "l_allow_screenshots_desc": "Permitir que outros aplicativos façam capturas de tela",
+    "s_link_my_yubico": null,
+    "p_link_my_yubico_desc": null,
     "@_nfc": {},
 
     "s_nfc_ready_to_scan": "Pronto para escanear",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1087,6 +1087,8 @@
     "l_launch_app_on_usb_off": "Другие приложения могут использовать YubiKey через USB",
     "s_allow_screenshots": "Разрешить скриншоты",
     "l_allow_screenshots_desc": "Разрешить другим приложениям делать снимки экрана",
+    "s_link_my_yubico": null,
+    "p_link_my_yubico_desc": null,
     "@_nfc": {},
 
     "s_nfc_ready_to_scan": "Готов к сканированию",

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -1087,6 +1087,8 @@
     "l_launch_app_on_usb_off": "Ostatné aplikácie môžu používať YubiKey cez USB",
     "s_allow_screenshots": "Povoliť snímky obrazovky",
     "l_allow_screenshots_desc": "Povoliť iným aplikáciám vytvárať snímky obrazovky",
+    "s_link_my_yubico": null,
+    "p_link_my_yubico_desc": null,
     "@_nfc": {},
 
     "s_nfc_ready_to_scan": "Pripravené na skenovanie",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -1087,6 +1087,8 @@
     "l_launch_app_on_usb_off": "Andra appar kan använda YubiKey via USB",
     "s_allow_screenshots": "Tillåt skärmdumpar",
     "l_allow_screenshots_desc": "Tillåt andra appar att ta skärmbilder",
+    "s_link_my_yubico": null,
+    "p_link_my_yubico_desc": null,
     "@_nfc": {},
 
     "s_nfc_ready_to_scan": "Redo att skanna",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -1087,6 +1087,8 @@
     "l_launch_app_on_usb_off": "แอปอื่น ๆ สามารถใช้ ยูบิคีย์ ผ่าน ยูเอสบี ได้",
     "s_allow_screenshots": "อนุญาตให้ถ่ายภาพหน้าจอ",
     "l_allow_screenshots_desc": "อนุญาตให้แอปอื่นถ่ายภาพหน้าจอ",
+    "s_link_my_yubico": null,
+    "p_link_my_yubico_desc": null,
     "@_nfc": {},
 
     "s_nfc_ready_to_scan": "พร้อมสแกน",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -1087,6 +1087,8 @@
     "l_launch_app_on_usb_off": "Diğer uygulamalar USB üzerinden YubiKey'i kullanabilir",
     "s_allow_screenshots": "Ekran görüntülerine izin ver",
     "l_allow_screenshots_desc": "Diğer uygulamaların ekran görüntüsü almasına izin verin",
+    "s_link_my_yubico": null,
+    "p_link_my_yubico_desc": null,
     "@_nfc": {},
 
     "s_nfc_ready_to_scan": "Taramaya hazır",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -1087,6 +1087,8 @@
     "l_launch_app_on_usb_off": "Інші програми можуть використовувати YubiKey через USB",
     "s_allow_screenshots": "Дозволити скріншоти",
     "l_allow_screenshots_desc": "Дозволити іншим програмам робити знімки екрана",
+    "s_link_my_yubico": null,
+    "p_link_my_yubico_desc": null,
     "@_nfc": {},
 
     "s_nfc_ready_to_scan": "Готовий до сканування",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -1087,6 +1087,8 @@
     "l_launch_app_on_usb_off": "Các ứng dụng khác có thể sử dụng YubiKey qua USB",
     "s_allow_screenshots": "Cho phép chụp ảnh màn hình",
     "l_allow_screenshots_desc": null,
+    "s_link_my_yubico": null,
+    "p_link_my_yubico_desc": null,
     "@_nfc": {},
 
     "s_nfc_ready_to_scan": "Sẵn sàng để quét",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1087,6 +1087,8 @@
     "l_launch_app_on_usb_off": "其他应用程序可通过 USB 使用 YubiKey",
     "s_allow_screenshots": "允许截图",
     "l_allow_screenshots_desc": "允许其他应用程序截屏",
+    "s_link_my_yubico": null,
+    "p_link_my_yubico_desc": null,
     "@_nfc": {},
 
     "s_nfc_ready_to_scan": "已准备好扫描",

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -1087,6 +1087,8 @@
     "l_launch_app_on_usb_off": "其他應用程式可透過 USB 使用 YubiKey",
     "s_allow_screenshots": "允許截圖",
     "l_allow_screenshots_desc": "允許其他應用程式截圖",
+    "s_link_my_yubico": null,
+    "p_link_my_yubico_desc": null,
     "@_nfc": {},
 
     "s_nfc_ready_to_scan": "準備掃描",


### PR DESCRIPTION
Attemps to fix #2189 

### Background

On Android 16 (API 36), NFC taps on a YubiKey no longer fire `NDEF_DISCOVERED`. The tag's NDEF record is treated as a regular `https://my.yubico.com/...` URL and dispatched via `ACTION_VIEW`. The app's manifest already declares an `autoVerify` intent filter for that host, but unless my.yubico.com is associated with the app (via Digital Asset Links auto-verification, or the user enabling it under **Settings → Apps → Yubico Authenticator → Open by default**), `ACTION_VIEW` falls through to a browser and the launch-on-tap setting silently does nothing.

Android 12–15 are unaffected: `NDEF_DISCOVERED` is still delivered there regardless of domain verification state.

### Approach

Use `DomainVerificationManager` (API 31+) to query whether `my.yubico.com` is associated with the app, and show a dialog with a direct link to the system "Open by default" settings page when it isn't.

The status check covers both conditions that allow `ACTION_VIEW` to be routed to the app:

1. `hostToStateMap[my.yubico.com]` must be `DOMAIN_STATE_VERIFIED` or `DOMAIN_STATE_SELECTED`.
2. `userState.isLinkHandlingAllowed` must be true — if the user disabled "Open supported links" globally for the app, `ACTION_VIEW` won't be routed here even when the host is individually verified or selected.

If either condition fails the prompt is shown.

**Note on "one tap" UX:** Android has no public API to programmatically grant per-domain link approval. `Settings.ACTION_APP_OPEN_BY_DEFAULT_SETTINGS` is the deepest available deep link — it lands directly on the per-app "Open by default" page where the user can enable "Open supported links" and verify `my.yubico.com` in two taps rather than navigating through system settings manually.

The prompt is shown at two points:

- **When the user selects a launch tap action** (`NfcTapAction.launch` / `NfcTapAction.launchAndCopy`) in NFC settings.
- **At startup**, once per app build (tracked in `SharedPreferences`), when a launch action is already configured. Users are reminded after install/update but not on every launch.

### Changes

**Kotlin / Android**

- New `DomainVerificationHelper` — guards on API 36, checks `isLinkHandlingAllowed` before `hostToStateMap`, swallows runtime exceptions to behave gracefully on quirky OEM builds.
- `MainActivity.AppMethodChannel` exposes `getDomainVerificationStatus` and `openDomainVerificationSettings` on the existing `app.methods` channel.

**Dart / Flutter**

- app_methods.dart — typed `DomainVerificationStatus` enum + channel bindings.
- domain_association_prompt.dart — `promptDomainAssociation()` (settings change) and `maybePromptDomainAssociationOnStartup()` (startup). Uses the shared `BasicDialog` widget.
- init.dart — invokes the startup variant in a post-frame callback when a launch action is configured.
- settings_page.dart — invokes the on-change variant when the user selects `launch` or `launchAndCopy`.

**Localization**

- app_en.arb — adds `s_link_my_yubico` and `p_link_my_yubico_desc`. Reuses existing `s_open_settings`. check_strings.py passes.

### Compatibility

- `minSdk = 24`, `compileSdk = 37`. The prompt is entirely suppressed below API 36 (`STATUS_UNSUPPORTED`). `DomainVerificationManager` calls are guarded on API 31 as required by the SDK, but the outer API-36 gate makes them unreachable on older releases.
- The legacy `NDEF_DISCOVERED` intent filter and `AliasNdefActivity` are unchanged — Android ≤15 behavior is unaffected.
- No new permissions.