### PR TITLE
a11y: touchups

### DIFF
--- a/lib/app/message.dart
+++ b/lib/app/message.dart
@@ -59,7 +59,6 @@ Future<T?> showBlurDialog<T>({
     scopesRoute: true,
     explicitChildNodes: true,
     namesRoute: true,
-    role: SemanticsRole.dialog,
     child: builder(ctx),
   ),
   transitionDuration: const Duration(milliseconds: 150),

--- a/lib/app/message.dart
+++ b/lib/app/message.dart
@@ -59,6 +59,7 @@ Future<T?> showBlurDialog<T>({
     scopesRoute: true,
     explicitChildNodes: true,
     namesRoute: true,
+    role: SemanticsRole.dialog,
     child: builder(ctx),
   ),
   transitionDuration: const Duration(milliseconds: 150),

--- a/lib/home/views/home_screen.dart
+++ b/lib/home/views/home_screen.dart
@@ -290,7 +290,8 @@ class _DeviceContent extends ConsumerWidget {
                                             _ColorButton(
                                               isDefault: true,
                                               color: defaultColor,
-                                              colorName: l10n.s_system_default,
+                                              colorName:
+                                                  '${l10n.s_color_green} / ${l10n.s_system_default}',
                                               isSelected: customColor == null,
                                               onPressed: () {
                                                 _updateColor(null, ref, serial);

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -79,7 +79,7 @@ class AppTheme {
         ),
         side: WidgetStateBorderSide.resolveWith((states) {
           if (!isAndroid && states.contains(WidgetState.focused)) {
-            return BorderSide(color: colorScheme.primary);
+            return BorderSide(color: colorScheme.primary, width: 1.4);
           }
           if (states.contains(WidgetState.disabled)) {
             return BorderSide(

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -89,7 +89,7 @@ class AppTheme {
           if (states.contains(WidgetState.selected)) {
             return BorderSide(color: Colors.transparent);
           }
-          return BorderSide(color: colorScheme.outline);
+          return BorderSide(color: colorScheme.outline, width: 1.4);
         }),
       ),
       listTileTheme: const ListTileThemeData(


### PR DESCRIPTION
Adding (role: SemanticsRole.dialog,) should in theory make screen readers read out dialog instead of group but doesn't work on Mac, maybe Windows?

Added color name to default color

Increased border width on ChipTheme