### PR TITLE
fix(qrscanner): register observer after init

### DIFF
--- a/android/flutter_plugins/qrscanner_zxing/android/src/main/kotlin/com/yubico/authenticator/flutter_plugins/qrscanner_zxing/QRScannerView.kt
+++ b/android/flutter_plugins/qrscanner_zxing/android/src/main/kotlin/com/yubico/authenticator/flutter_plugins/qrscanner_zxing/QRScannerView.kt
@@ -296,11 +296,12 @@ internal class QRScannerView(
 
             cameraController = controller
 
-            // Observe camera state
-            controller.cameraInfo?.cameraState?.let {
-                it.removeObservers(owner)
-                it.observe(owner, stateChangeObserver)
-            }
+            controller.initializationFuture.addListener({
+                controller.cameraInfo?.cameraState?.let {
+                    it.removeObservers(owner)
+                    it.observe(owner, stateChangeObserver)
+                }
+            }, ContextCompat.getMainExecutor(context))
 
             reportViewInitialized(true)
         } catch (e: IllegalArgumentException) {


### PR DESCRIPTION
## Summary

`StateChangeObserver` was never registered because `controller.cameraInfo`
is `null` immediately after `bindToLifecycle()` — camera binding happens
asynchronously. The observer is now attached inside
`initializationFuture.addListener`, guaranteeing `cameraInfo` is non-null
when the subscription is made.

## Changes

- Wrap `cameraState` observer registration in
  `controller.initializationFuture.addListener` so it runs after the
  camera is fully initialized