### PR TITLE
fix(macos): hide Dock icon when window is hidden

### DIFF
--- a/lib/desktop/state.dart
+++ b/lib/desktop/state.dart
@@ -100,7 +100,13 @@ class DesktopWindowStateNotifier extends StateNotifier<WindowState>
   void setWindowHidden(bool hidden) async {
     if (hidden) {
       await windowManager.hide();
+      if (Platform.isMacOS) {
+        await windowManager.setSkipTaskbar(true);
+      }
     } else {
+      if (Platform.isMacOS) {
+        await windowManager.setSkipTaskbar(false);
+      }
       await windowManager.show();
     }
     await _prefs.setBool(windowHidden, hidden);


### PR DESCRIPTION
In the current version of Yubico Authenticator for macOS, 7.3.3, pressing Cmd+W hides the main window, however the app still continues to appear in the Dock.

This is normal for regular macOS apps after closing their last window. Except here, the app is already running in the menu bar, so keeping it in the Dock too feels rather redundant.

Tested on macOS 26.5.1.