### PR TITLE
build: speed up CI builds and slim the release APK

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,6 +17,12 @@ jobs:
         with:
           path: 'app'
 
+      # Caches ~/.gradle (dependencies + build cache) across runs. Gradle is
+      # invoked through Flutter here, but the cache is home-dir based so both the
+      # `flutter build apk` and `./gradlew test` steps benefit.
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+
       - name: Read variables from repo
         run: cat .github/workflows/env >> $GITHUB_ENV
         working-directory: ./app
@@ -26,6 +32,7 @@ jobs:
         with:
           channel: 'stable'
           flutter-version: ${{ env.FLUTTER }}
+          cache: true
       - run: |
           flutter config
           flutter --version

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Set up JDK 21
-        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -21,7 +21,7 @@ jobs:
       # invoked through Flutter here, but the cache is home-dir based so both the
       # `flutter build apk` and `./gradlew test` steps benefit.
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Read variables from repo
         run: cat .github/workflows/env >> $GITHUB_ENV

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,6 +43,11 @@ jobs:
         with:
           path: 'app'
 
+      # Caches Gradle dependencies. The Gradle build cache is deliberately kept
+      # off for the build step below so CodeQL's tracer sees full compilation.
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+
       - name: Read variables from repo
         run: cat .github/workflows/env >> $GITHUB_ENV
         working-directory: ./app
@@ -52,6 +57,7 @@ jobs:
         with:
           channel: 'stable'
           flutter-version: ${{ env.FLUTTER }}
+          cache: true
       - run: |
           flutter config
           flutter --version
@@ -74,6 +80,9 @@ jobs:
         name: Build the App
         run: android/scripts/build.sh
         env:
+          # Disable the Gradle build cache so CodeQL always traces a real
+          # compilation; a cached KotlinCompile would drop classes from the DB.
+          GRADLE_OPTS: -Dorg.gradle.caching=false
           YUBIOATH_STORE_BASE64: ${{ secrets.YUBIOATH_STORE_BASE64 }}
           YUBIOATH_KEY_ALIAS: ${{ secrets.YUBIOATH_KEY_ALIAS }}
           YUBIOATH_KEY_PASSWORD: ${{ secrets.YUBIOATH_KEY_PASSWORD }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,13 +28,13 @@ jobs:
 
     steps:
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: ${{ matrix.language }}
           setup-python-dependencies: false
 
       - name: set up JDK 21
-        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -46,7 +46,7 @@ jobs:
       # Caches Gradle dependencies. The Gradle build cache is deliberately kept
       # off for the build step below so CodeQL's tracer sees full compilation.
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Read variables from repo
         run: cat .github/workflows/env >> $GITHUB_ENV
@@ -91,7 +91,7 @@ jobs:
 
       - if: matrix.language == 'python'
         name: autobuild
-        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0

--- a/.github/workflows/linux-arm64.yml
+++ b/.github/workflows/linux-arm64.yml
@@ -52,7 +52,7 @@ jobs:
         git diff --exit-code
 
     - name: Install uv
-      uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       with:
         enable-cache: true
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Install uv
-      uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       with:
         enable-cache: true
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,7 +32,7 @@ jobs:
         podfile-path: macos/Podfile.lock
 
     - name: Install uv
-      uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       with:
         enable-cache: true
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,7 +29,7 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install uv
-        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -83,6 +83,17 @@ android {
         }
     }
 
+    // Emit per-ABI and universal APKs from a single assemble, so the release
+    // build needs one `flutter build apk` instead of two.
+    splits {
+        abi {
+            enable true
+            reset()
+            include 'armeabi-v7a', 'arm64-v8a', 'x86_64'
+            universalApk true
+        }
+    }
+
     ndkVersion = flutter.ndkVersion
 }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -75,6 +75,11 @@ android {
             excludes += 'META-INF/versions/9/OSGI-INF/MANIFEST.MF'
             excludes += 'META-INF/versions/9/OSGI-INF/bcprov.provider.bc.Licenses'
             excludes += 'META-INF/versions/9/OSGI-INF/bcpkix.provider.bc.Licenses'
+            // Unused BouncyCastle Picnic LowMC matrices (~1.2 MB). R8 and resource
+            // shrinking don't strip jar resources, so exclude them explicitly.
+            excludes += 'org/bouncycastle/pqc/legacy/picnic/lowmcL1.bin.properties'
+            excludes += 'org/bouncycastle/pqc/legacy/picnic/lowmcL3.bin.properties'
+            excludes += 'org/bouncycastle/pqc/legacy/picnic/lowmcL5.bin.properties'
         }
     }
 

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -5,54 +5,24 @@
 # For more details, see
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
+# kotlinx.serialization keep rules are intentionally NOT declared here.
+# kotlinx-serialization-core ships them inside the jar
+# (META-INF/com.android.tools/r8/*.pro, including the R8 full-mode rules) and R8
+# applies them automatically.
+
+# yubikit keep rules are intentionally NOT declared here. The
+# com.yubico.yubikit:android AAR ships them as consumer rules, including
+# `-keepnames class com.yubico.yubikit.**`, which already preserves exception
+# class names so they are not obfuscated in log output.
+
 -dontwarn edu.umd.cs.findbugs.annotations.SuppressFBWarnings
-
-
-# Keep `Companion` object fields of serializable classes.
-# This avoids serializer lookup through `getDeclaredClasses` as done for named companion objects.
--if @kotlinx.serialization.Serializable class **
--keepclassmembers class <1> {
-    static <1>$Companion Companion;
-}
-
-# Keep `serializer()` on companion objects (both default and named) of serializable classes.
--if @kotlinx.serialization.Serializable class ** {
-    static **$* *;
-}
--keepclassmembers class <2>$<3> {
-    kotlinx.serialization.KSerializer serializer(...);
-}
-
-# Keep `INSTANCE.serializer()` of serializable objects.
--if @kotlinx.serialization.Serializable class ** {
-    public static ** INSTANCE;
-}
--keepclassmembers class <1> {
-    public static <1> INSTANCE;
-    kotlinx.serialization.KSerializer serializer(...);
-}
-
-# @Serializable and @Polymorphic are used at runtime for polymorphic serialization.
--keepattributes RuntimeVisibleAnnotations,AnnotationDefault
-
-# Serializer for classes with named companion objects are retrieved using `getDeclaredClasses`.
-# If you have any, uncomment and replace classes with those containing named companion objects.
-#-keepattributes InnerClasses # Needed for `getDeclaredClasses`.
-#-if @kotlinx.serialization.Serializable class
-#com.example.myapplication.HasNamedCompanion, # <-- List serializable classes with named companions.
-#com.example.myapplication.HasNamedCompanion2
-#{
-#    static **$* *;
-#}
-#-keepnames class <1>$$serializer { # -keepnames suffices; class is kept when serializer() is kept.
-#    static <1>$$serializer INSTANCE;
-#}
 
 # app specific rules
 -keep public class com.yubico.authenticator.logging.BufferAppender
 -keepclassmembers class com.yubico.authenticator.logging.BufferAppender { *; }
 
-# consumer rules for logcat-android
+# consumer rules for logback-android
+# The logback-android AAR ships no proguard.txt, so we carry its rules here.
 # see: https://github.com/tony19/logback-android/blob/v_3.0.0/logback-android/consumer-rules.pro
 -keepclassmembers class ch.qos.logback.classic.pattern.* { <init>(); }
 
@@ -65,7 +35,7 @@
 
 -keep class org.bouncycastle.** { *; }
 
-# these are not part of Android SDK
+# these are not part of Android SDK (referenced by logback via JNDI)
 -dontwarn javax.naming.Binding
 -dontwarn javax.naming.NamingEnumeration
 -dontwarn javax.naming.NamingException
@@ -75,6 +45,3 @@
 -dontwarn javax.naming.directory.InitialDirContext
 -dontwarn javax.naming.directory.SearchControls
 -dontwarn javax.naming.directory.SearchResult
-
-# don't ubfuscate exception names
--keep class com.yubico.yubikit.core.** extends java.lang.Exception { *; }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,3 +3,9 @@ android.useAndroidX=true
 android.newDsl=false
 android.builtInKotlin=false
 android.uniquePackageNames=false
+
+# Build performance: reuse task outputs (pairs with the CI ~/.gradle cache) and
+# build independent tasks in parallel. Configuration cache is intentionally left
+# off: the Flutter and oss-licenses Gradle plugins are not compatible with it.
+org.gradle.caching=true
+org.gradle.parallel=true

--- a/android/scripts/build.sh
+++ b/android/scripts/build.sh
@@ -5,6 +5,6 @@ pushd android
 ./gradlew collectLicenses
 popd
 
-# Build flutter app
+# Build flutter app. The abi splits config (universalApk) makes this single
+# command emit both the per-ABI APKs and the universal app-release.apk.
 flutter build apk --release --split-per-abi
-flutter build apk --release


### PR DESCRIPTION
## Summary

Build-performance and hygiene pass on the Android build. Cuts the Android CI build from ~14m to ~10m, mainly by producing all release APKs in a single Flutter build instead of two, with dependency caching on top. Also drops ~1.2 MB of unused data from the APK and removes ProGuard/R8 rules now supplied by the dependencies. No app behaviour changes.

## Changes

### Build time
- Emit the per-ABI and universal APKs from a single `assemble` via an ABI splits block with `universalApk true`, and drop the second `flutter build apk --release` from `build.sh`. Previously each of the two builds re-ran Dart AOT, Kotlin compile and R8. Artifact filenames are unchanged, so `collect-artifacts.sh` needs no changes.
- Cache the Gradle dependency graph and Flutter SDK in the Android workflow (`setup-gradle` + `flutter-action` caching).
- Enable the Gradle build cache and parallel execution in `gradle.properties` so warm caches translate into skipped work. Configuration cache is intentionally left off (Flutter and oss-licenses plugins are incompatible with it).
- Add the same dependency/Flutter caching to the CodeQL workflow, but keep the Gradle build cache disabled there so CodeQL's tracer always sees a full compilation and no classes drop out of the database.

### Release APK size
- Exclude the BouncyCastle Picnic (legacy PQC) LowMC matrices (~1.2 MB); they ship in bcprov but are never used, and neither R8 nor resource shrinking strips jar resources. Verified via before/after release builds.
- Drop the hand-copied kotlinx.serialization keep rules; the serialization artifact already ships them (including R8 full-mode rules) in the jar.
- Drop the yubikit exception keep rule; the yubikit:android AAR already ships `-keepnames class com.yubico.yubikit.**`.

### Dependency maintenance
- Bump pinned GitHub Actions to latest: codeql-action v4.37.0, setup-java v5.5.0, setup-gradle v6.2.0, setup-uv v8.3.2, each pinned to a full SHA.

## Build times (Android workflow)
| Run | Time |
|---|---|
| Baseline (`main`, pre-change) | 13m 58s |
| This branch — caching only (warm) | 12m 56s |
| This branch — all changes (warm) | 10m 10s |